### PR TITLE
chore: track the main branch ruleset in the repo

### DIFF
--- a/.github/rulesets/README.md
+++ b/.github/rulesets/README.md
@@ -1,0 +1,27 @@
+# Rulesets
+
+Rulesets are repository *settings*, not configuration GitHub reads from the tree — a file here
+does nothing until it is imported. It lives in the repo so the protection on `main` is reviewable
+in a diff instead of being a thing someone once clicked.
+
+Apply or update:
+
+```sh
+gh api repos/nofayz/zuno/rulesets --input .github/rulesets/main.json          # create
+gh api --method PUT repos/nofayz/zuno/rulesets/<id> --input .github/rulesets/main.json  # update
+```
+
+`gh api repos/nofayz/zuno/rulesets` lists the ids. The UI equivalent is Settings → Rules →
+Rulesets → New ruleset → Import a ruleset.
+
+## What `main.json` does
+
+- No deletion, no force-push.
+- Changes arrive by pull request. **Zero** approvals required — this is a solo-maintained repo, and
+  a review count of one would lock the maintainer out of their own default branch, since nobody can
+  approve their own PR.
+- `verify` and `rust` — both CI jobs — must pass first. Not strict: a branch does not have to be
+  rebased onto the newest `main` before merging, which on a repo this size is churn without a
+  matching risk.
+- No bypass actors. An admin can still edit the ruleset itself, so the escape hatch exists without
+  a standing exemption that quietly makes the rules advisory.

--- a/.github/rulesets/README.md
+++ b/.github/rulesets/README.md
@@ -7,12 +7,12 @@ in a diff instead of being a thing someone once clicked.
 Apply or update:
 
 ```sh
-gh api repos/nofayz/zuno/rulesets --input .github/rulesets/main.json          # create
-gh api --method PUT repos/nofayz/zuno/rulesets/<id> --input .github/rulesets/main.json  # update
+gh api --method PUT repos/noFAYZ/zuno/rulesets/20021321 --input .github/rulesets/main.json
 ```
 
-`gh api repos/nofayz/zuno/rulesets` lists the ids. The UI equivalent is Settings → Rules →
-Rulesets → New ruleset → Import a ruleset.
+`main.json` is applied — id `20021321`, created 2026-07-30. Edit the file, run the command, and the
+two stay in step; skip the command and the file is fiction. `gh api repos/noFAYZ/zuno/rulesets`
+lists what is actually live. The UI equivalent is Settings → Rules → Rulesets.
 
 ## What `main.json` does
 

--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -1,0 +1,35 @@
+{
+  "name": "main",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["~DEFAULT_BRANCH"],
+      "exclude": []
+    }
+  },
+  "bypass_actors": [],
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false,
+        "allowed_merge_methods": ["merge", "squash", "rebase"]
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [{ "context": "verify" }, { "context": "rust" }]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
The ruleset protecting `main` was a thing someone clicked in Settings. This puts it in the tree as
`.github/rulesets/main.json`, so the protection is reviewable in a diff and restorable if it is
ever deleted.

Applied live as ruleset `20021321`. The README next to it carries the `gh api` command that keeps
the file and the live setting in step — the file does nothing on its own.

