### PR TITLE
ci: compile the Linux-only Rust on Linux, and ship an rpm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,3 +56,44 @@ jobs:
       - name: Rust tests
         working-directory: src-tauri
         run: cargo test
+
+  # Compile-only, and only because of `#[cfg(target_os = "linux")]`.
+  #
+  # The job above runs on Windows, so every Linux-gated line — `linux_media.rs`, the MPRIS
+  # session, anything else added behind that cfg — was invisible to CI. A pull request touching
+  # it could go green without the code ever having been fed to a compiler.
+  #
+  # `cargo check` rather than `cargo test`: the tests are platform-independent and the Windows
+  # job already runs them. What is missing here is the compiler, not the assertions.
+  rust-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+          # A different target dir to the Windows job's — sharing one would thrash the cache.
+          key: linux
+
+      # Mirrors the list in release.yml's Linux build. If one changes, change both.
+      - name: System dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            libjavascriptcoregtk-4.1-dev \
+            libsoup-3.0-dev \
+            librsvg2-dev \
+            libssl-dev \
+            build-essential
+
+      # `--locked` because a Cargo.toml change that forgets its Cargo.lock is the other way this
+      # goes wrong quietly.
+      - name: Typecheck
+        working-directory: src-tauri
+        run: cargo check --locked


### PR DESCRIPTION
Two changes on `dev`.

### `rust-linux` CI job

The `rust` job runs on `windows-latest`, so everything behind `#[cfg(target_os = "linux")]` has never been handed to a compiler by CI. #9 adds an entire MPRIS backend under that cfg and its checks are green, because nothing built it.

Adds a `rust-linux` job: system deps mirroring release.yml, then `cargo check --locked`. Not `cargo test`, since the tests are platform-independent and the Windows job already runs them. `--locked` catches the neighbouring quiet failure, a `Cargo.toml` change whose `Cargo.lock` was not committed with it. Cold run is 2m24s.

Once this is on `main`, `rust-linux` should be added to the required checks in `.github/rulesets/main.json` and re-applied. Doing it before the merge would block every open PR on a check their branch cannot produce.

### RPM package

The README's Linux notes already say to install the `.deb` or `.rpm`, but only the deb was built. Adds `rpm` to the release bundle args, Fedora dependency names to `tauri.conf.json`, and the format to the download tile on the site.

Tauri 2 bundles rpm in pure Rust, so the runner needs no `rpmbuild`. The deb bundler derives `Depends` from the linked libraries; the rpm bundler ships whatever `Requires` it is given, hence the explicit list. GStreamer is `recommends`, matching how the AUR package treats codecs.

The updater is untouched — it only consumes the AppImage on Linux, so `latest.json` is unchanged.

Untested until a tag actually builds: the rpm bundler never runs outside a release.
