### PR TITLE
Set Linux desktop entry category so app shows in menu

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -31,11 +31,11 @@
     "active": true,
     "targets": "all",
     "createUpdaterArtifacts": true,
+    "category": "Music",
     "linux": {
       "appimage": {
         "bundleMediaFramework": true
-      },
-      "category": "AudioVideo;Audio;Music"
+      }
     },
     "icon": [
       "icons/32x32.png",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -34,7 +34,8 @@
     "linux": {
       "appimage": {
         "bundleMediaFramework": true
-      }
+      },
+      "category": "AudioVideo;Audio;Music"
     },
     "icon": [
       "icons/32x32.png",


### PR DESCRIPTION
## Summary

The Linux `.desktop` file generated by the bundler currently ships with an empty `Categories=` field:

```ini
[Desktop Entry]
Categories=
...
```

Because `Categories` is empty, XDG-compliant launchers (KDE Kickoff/Application Launcher, GNOME, etc.) have no category to place the entry under, so Zuno does not appear in the categorized application menu (e.g. KDE's Multimedia section). The app is only reachable by direct search, which makes it easy to miss.

`desktop-file-validate` does not flag this because an empty value is syntactically valid per the freedesktop.org Desktop Entry Spec, but it is functionally useless.

## Change

Add `category` to the existing `bundle.linux` block in `src-tauri/tauri.conf.json` (which already contained `appimage.bundleMediaFramework`), so the bundler emits a proper `Categories=` line:

```json
"bundle": {
  ...
  "linux": {
    "appimage": {
      "bundleMediaFramework": true
    },
    "category": "AudioVideo;Audio;Music"
  }
}
```

These are the registered freedesktop categories for music/audio applications:
https://specifications.freedesktop.org/menu-spec/latest/apa.html#main-category-registry

After this change, the generated `.desktop` file will contain:

```ini
Categories=AudioVideo;Audio;Music;
```

and Zuno will appear under Multimedia in KDE and equivalent sections in other launchers.

## Test plan

- [ ] Build the Linux bundle (`npm run tauri build`)
- [ ] Verify the generated `Zuno.desktop` contains `Categories=AudioVideo;Audio;Music;`
- [ ] `desktop-file-validate Zuno.desktop` passes
- [ ] Install the resulting package and confirm Zuno appears under Multimedia in KDE