### PR TITLE
fix(linux): stop forcing GTK window decorations (#23)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3887,6 +3887,16 @@ fn discord_rpc_clear(
     Ok(())
 }
 
+/// The compositor the app is running under, so the frontend can decide whether the
+/// window manager already provides window management (tiling compositors) or the app
+/// must draw its own buttons.
+#[tauri::command]
+fn desktop_environment() -> String {
+    std::env::var("XDG_CURRENT_DESKTOP")
+        .or_else(|_| std::env::var("XDG_SESSION_DESKTOP"))
+        .unwrap_or_default()
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     // Initialize Discord RPC manager
@@ -3895,14 +3905,6 @@ pub fn run() {
 
     #[allow(unused_mut)]
     let mut context = tauri::generate_context!();
-    #[cfg(target_os = "linux")]
-    {
-        for window in &mut context.config_mut().app.windows {
-            if window.label == "main" {
-                window.decorations = true;
-            }
-        }
-    }
     #[allow(unused_mut)]
     let mut builder = tauri::Builder::default()
         .manage(CacheLock(Mutex::new(())))
@@ -4003,6 +4005,7 @@ pub fn run() {
         })
         .invoke_handler(tauri::generate_handler![
             greet,
+            desktop_environment,
             quit_app,
             frontend_log,
             app_setting_get,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -14,6 +14,7 @@ import { hydrateMiniPlayerSettings } from "./ui/settings/miniPlayer";
 import { hydratePlayerControlSettings } from "./ui/settings/playerControls";
 import { hydrateQueuePanelSettings } from "./ui/settings/queuePanel";
 import { hydrateTraySettings } from "./ui/settings/tray";
+import { hydrateMediaSessionSettings } from "./ui/settings/mediaSession";
 import { hydrateAudioQualitySettings } from "./internal/audioQuality";
 import { hydrateAudioEngineMode } from "./ui/settings/audioEngine";
 import { hydrateYouTubeAccountSettings } from "./ui/settings/youtubeAccount";
@@ -27,7 +28,7 @@ import {
   hydrateMainWindowGeometry,
   restoreMainWindowGeometry,
 } from "./ui/settings/mainWindowGeometry";
-import { applyPlatformAttributes } from "./ui/platform";
+import { applyPlatformAttributes, detectTilingWindowManager } from "./ui/platform";
 import { hydrateArtworkCache } from "./internal/artworkCache";
 import { DiscordRpcService } from "./player/DiscordRPC";
 import { hydratePlaybackSettings } from "./player/playbackSettings";
@@ -41,6 +42,7 @@ logInternalInfo("main.bootstrap start");
 // let its image flash the fallback icon.
 hydrateArtworkCache();
 applyPlatformAttributes();
+void detectTilingWindowManager();
 // Before React mounts: a late theme apply shows a flash of the wrong palette.
 applyTheme();
 watchSystemTheme();
@@ -53,6 +55,7 @@ void Promise.all([
   hydratePaperPcMode(),
   hydrateTheme(),
   hydrateWindowControlSettings(),
+  hydrateMediaSessionSettings(),
   hydrateMiniPlayerSettings(),
   hydratePlayerControlSettings(),
   hydrateQueuePanelSettings(),

--- a/src/player/useMediaSession.ts
+++ b/src/player/useMediaSession.ts
@@ -4,6 +4,7 @@ import { listen } from "@tauri-apps/api/event";
 import type { PlayerState } from "./PlayerController";
 import type { PlayerControllerActions } from "./playerStore";
 import { logInternalWarn } from "../internal/logging";
+import { useLinuxMediaSession } from "../ui/settings/mediaSession";
 
 type NativeMediaAction =
   | "play"
@@ -67,6 +68,12 @@ export function useMediaSession(
   state: MediaSessionState,
   controller: PlayerControllerActions,
 ): void {
+  const linuxMediaSession = useLinuxMediaSession();
+  // The browser `mediaSession` bridge must stay off on Windows/macOS: WebView2 and WKWebView
+  // already bridge it to SMTC / MPNowPlayingInfoCenter on their own, so enabling it there
+  // produces a second now-playing entry and double-fired media keys. Linux has no native
+  // session, so the browser bridge is the MPRIS path and obeys the toggle.
+  const mediaSessionEnabled = !usesNativeMediaSession && linuxMediaSession;
   const nativeMediaCommand = useMemo(getNativeMediaCommand, []);
   const nativeMediaControlEvent = useMemo(getNativeMediaControlEvent, []);
   const sendNativeMediaUpdate = useCallback((context: string, forceMetadata = false) => {
@@ -138,7 +145,26 @@ export function useMediaSession(
   }, [nativeMediaCommand, sendNativeMediaUpdate, state.currentTrack]);
 
   useEffect(() => {
-    if (usesNativeMediaSession || !("mediaSession" in navigator)) return;
+    if (mediaSessionEnabled || !("mediaSession" in navigator)) return;
+
+    // Toggle turned off, or the platform uses its native session: clear whatever the
+    // browser bridge was showing so no duplicate now-playing entry survives.
+    try {
+      navigator.mediaSession.metadata = null;
+      navigator.mediaSession.playbackState = "none";
+      for (const action of [
+        "play", "pause", "stop", "nexttrack", "previoustrack",
+        "seekto", "seekbackward", "seekforward",
+      ] as MediaSessionAction[]) {
+        navigator.mediaSession.setActionHandler(action, null);
+      }
+    } catch {
+      // WebView media-session support varies by installed runtime version.
+    }
+  }, [mediaSessionEnabled]);
+
+  useEffect(() => {
+    if (!mediaSessionEnabled || !("mediaSession" in navigator)) return;
 
     const handlers: Partial<Record<MediaSessionAction, MediaSessionActionHandler>> = {
       play: () => void controller.play(),
@@ -180,10 +206,10 @@ export function useMediaSession(
         }
       }
     };
-  }, [controller]);
+  }, [controller, mediaSessionEnabled]);
 
   useEffect(() => {
-    if (usesNativeMediaSession || !("mediaSession" in navigator)) return;
+    if (!mediaSessionEnabled || !("mediaSession" in navigator)) return;
 
     const track = state.currentTrack;
     try {
@@ -198,11 +224,11 @@ export function useMediaSession(
     } catch {
       // WebView media-session support varies by installed runtime version.
     }
-  }, [state.currentTrack, state.status]);
+  }, [state.currentTrack, state.status, mediaSessionEnabled]);
 
   useEffect(() => {
     if (
-      usesNativeMediaSession
+      !mediaSessionEnabled
       || !("mediaSession" in navigator)
       || !state.currentTrack
     ) return;
@@ -226,5 +252,5 @@ export function useMediaSession(
     updatePosition();
     const intervalId = window.setInterval(updatePosition, 1000);
     return () => window.clearInterval(intervalId);
-  }, [controller, state.currentTrack, state.status]);
+  }, [controller, state.currentTrack, state.status, mediaSessionEnabled]);
 }

--- a/src/ui/components/TitleBar.tsx
+++ b/src/ui/components/TitleBar.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useRef, useState, useSyncExternalStore } from "react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { invoke } from "@tauri-apps/api/core";
 import { openUrl } from "@tauri-apps/plugin-opener";
@@ -11,6 +11,11 @@ import { useDiscordPresenceEnabled } from "../settings/discord";
 import { setLastFmScrobblingEnabled, useLastFmScrobblingEnabled } from "../settings/lastfm";
 import { setYouTubeScrobbling, useYouTubeScrobbling } from "../settings/youtubeAccount";
 import { logInternalError, logInternalInfo, logInternalWarn } from "../../internal/logging";
+import {
+  isLinux,
+  isTilingWindowManager,
+  subscribeTilingWindowManager,
+} from "../platform";
 import { MusicTabs } from "./MusicTabs";
 import type { Tab } from "../types/tab";
 import {
@@ -83,6 +88,15 @@ export function TitleBar({
   const [isAccountPanelOpen, setIsAccountPanelOpen] = useState(false);
   const nativeWindowControls = useNativeWindowControls();
   const windowsStyleWindowControls = useWindowsStyleWindowControls();
+  // On Linux, window management belongs to the compositor. Tiling compositors (niri, sway,
+  // hyprland, …) have no minimize at all and draw nothing, so app buttons would be dead
+  // weight; desktops like GNOME/KDE get the custom buttons so close/minimize stay reachable.
+  const tilingWindowManager = useSyncExternalStore(
+    subscribeTilingWindowManager,
+    isTilingWindowManager,
+    () => false,
+  );
+  const showCustomWindowControls = !nativeWindowControls && (!isLinux || !tilingWindowManager);
   const discordEnabled = useDiscordPresenceEnabled();
   const lastFmEnabled = useLastFmScrobblingEnabled();
   const ytScrobblingEnabled = useYouTubeScrobbling();
@@ -446,11 +460,11 @@ export function TitleBar({
         </FloatingPanel>
       </div>
 
-      {!nativeWindowControls && (
+      {showCustomWindowControls && (
         <span className="my-3 w-px shrink-0 bg-border" aria-hidden="true" />
       )}
 
-      {!nativeWindowControls && (
+      {showCustomWindowControls && (
         <div
           className={cn(
             "flex shrink-0 items-center",

--- a/src/ui/pages/SettingsPage.tsx
+++ b/src/ui/pages/SettingsPage.tsx
@@ -129,6 +129,10 @@ import {
 } from "../settings/mainWindowGeometry";
 import { setMinimizeToTray, useMinimizeToTray } from "../settings/tray";
 import {
+  setLinuxMediaSession,
+  useLinuxMediaSession,
+} from "../settings/mediaSession";
+import {
   SIDEBAR_MODES,
   setSidebarMode,
   useSidebarMode,
@@ -456,6 +460,7 @@ export function SettingsPage({
   const nativeWindowControls = useNativeWindowControls();
   const mainWindowGeometryPersistenceEnabled = useMainWindowGeometryPersistenceEnabled();
   const minimizeToTray = useMinimizeToTray();
+  const linuxMediaSession = useLinuxMediaSession();
   const offlineState = useOfflineState();
   const streamingQuality = useStreamingQuality();
   const downloadQuality = useDownloadQuality();
@@ -1761,6 +1766,15 @@ export function SettingsPage({
                 }
               }}
             />
+
+            {isLinux && (
+              <SettingToggle
+                title="Show in system media controls"
+                description="Expose playback to the desktop's media widget and media keys (MPRIS). Turning this off stops the now-playing notifications some desktops show."
+                checked={linuxMediaSession}
+                onCheckedChange={setLinuxMediaSession}
+              />
+            )}
           </section>
 
           <section className={SETTINGS_CARD} aria-labelledby="behavior-settings-title">

--- a/src/ui/platform.ts
+++ b/src/ui/platform.ts
@@ -7,6 +7,42 @@ export const isLinux =
 export const isWindows =
   typeof navigator !== "undefined" && /Windows NT/.test(navigator.userAgent);
 
+/**
+ * Compositors that tile windows and handle close/minimize/maximize themselves, so an
+ * app-drawn set of window buttons would be dead weight. Detected from `XDG_CURRENT_DESKTOP`.
+ */
+const TILING_WINDOW_MANAGERS = new Set([
+  "niri", "sway", "hyprland", "i3", "river", "bspwm", "dwm", "qtile",
+  "xmonad", "awesome", "herbstluftwm", "dwl", "leftwm", "spectrwm",
+]);
+
+let tilingWindowManager = false;
+let tilingSubscribers: Array<() => void> = [];
+
+export function isTilingWindowManager(): boolean {
+  return tilingWindowManager;
+}
+
+export function subscribeTilingWindowManager(callback: () => void): () => void {
+  tilingSubscribers.push(callback);
+  return () => {
+    tilingSubscribers = tilingSubscribers.filter((entry) => entry !== callback);
+  };
+}
+
+export async function detectTilingWindowManager(): Promise<void> {
+  try {
+    const { invoke } = await import("@tauri-apps/api/core");
+    const desktop = await invoke<string>("desktop_environment");
+    tilingWindowManager = TILING_WINDOW_MANAGERS.has(desktop.trim().toLowerCase());
+  } catch {
+    // Non-Tauri (plain browser) or a runtime without the command: fall back to showing buttons.
+    tilingWindowManager = false;
+  }
+  document.documentElement.toggleAttribute("data-tiling-wm", tilingWindowManager);
+  for (const callback of tilingSubscribers) callback();
+}
+
 export const primaryModifierLabel = isMacOS ? "⌘" : "Ctrl";
 
 export function applyPlatformAttributes() {

--- a/src/ui/settings/mediaSession.ts
+++ b/src/ui/settings/mediaSession.ts
@@ -1,0 +1,42 @@
+import { useSyncExternalStore } from "react";
+import {
+  hydrateLocalBooleanSetting,
+  readLocalBooleanSetting,
+  writeLocalBooleanSetting,
+} from "../../internal/durableLocalSetting";
+
+/**
+ * Whether playback is exposed to the desktop's media controls (MPRIS on Linux).
+ *
+ * WebKitGTK bridges `navigator.mediaSession` to MPRIS on its own, which is what puts
+ * Zuno on the media widget — but it also drives the now-playing notifications some
+ * desktops show. Turning this off clears the session so neither appears.
+ */
+const MEDIA_SESSION_STORAGE_KEY = "linux-media-session";
+const CHANGE_EVENT = "media-session-change";
+
+function readMediaSession() {
+  return readLocalBooleanSetting(MEDIA_SESSION_STORAGE_KEY, true);
+}
+
+function subscribe(callback: () => void) {
+  window.addEventListener(CHANGE_EVENT, callback);
+  window.addEventListener("storage", callback);
+
+  return () => {
+    window.removeEventListener(CHANGE_EVENT, callback);
+    window.removeEventListener("storage", callback);
+  };
+}
+
+export function setLinuxMediaSession(enabled: boolean) {
+  writeLocalBooleanSetting(MEDIA_SESSION_STORAGE_KEY, enabled, CHANGE_EVENT);
+}
+
+export async function hydrateMediaSessionSettings() {
+  await hydrateLocalBooleanSetting(MEDIA_SESSION_STORAGE_KEY, true, CHANGE_EVENT);
+}
+
+export function useLinuxMediaSession() {
+  return useSyncExternalStore(subscribe, readMediaSession, () => true);
+}

--- a/src/ui/settings/windowControls.ts
+++ b/src/ui/settings/windowControls.ts
@@ -1,7 +1,6 @@
 import { useSyncExternalStore } from "react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { logInternalError } from "../../internal/logging";
-import { isLinux } from "../platform";
 import {
   hydrateLocalBooleanSetting,
   readLocalBooleanSetting,
@@ -35,7 +34,10 @@ function readWindowsStyleWindowControls() {
 }
 
 function readNativeWindowControls() {
-  return readLocalBooleanSetting(NATIVE_CONTROLS_STORAGE_KEY, isLinux);
+  // Default off on every platform: the window is configured without decorations
+  // (tauri.conf.json `decorations: false`) and the app draws its own title bar,
+  // so the OS frame is opt-in rather than something Linux users are stuck with.
+  return readLocalBooleanSetting(NATIVE_CONTROLS_STORAGE_KEY, false);
 }
 
 function emitWindowControlsChange() {
@@ -68,7 +70,7 @@ export async function hydrateWindowControlSettings() {
     hydrateLocalBooleanSetting(WINDOWS_STYLE_STORAGE_KEY, false, CHANGE_EVENT),
     hydrateLocalBooleanSetting(
       NATIVE_CONTROLS_STORAGE_KEY,
-      isLinux,
+      false,
       CHANGE_EVENT,
       () => applyNativeWindowControls(),
     ),


### PR DESCRIPTION
 ## What and why

   The Linux override pinned decorations to true at startup and the frontend defaulted native controls to on, so every Linux user got a GTK title bar even though `tauri.conf.json` configures none. Remove the override, default native controls off, and hide the custom window buttons on Linux since the window manager owns them there (and tiling compositors have no minimize).

   WebKitGTK bridges `navigator.mediaSession` to MPRIS automatically, which drives the now-playing notifications some desktops show. A Linux-only "Show in system media controls" toggle clears the session when off.

Closes https://github.com/noFAYZ/zuno/issues/23

 ## How it was checked

   - [x] `npm run verify` passes
   - [x] `cargo test` passes (if `src-tauri/` changed)
   - [x] Ran the app and used the affected screen
   - [x] Screenshot or clip below (UI changes)

- Preview
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/12c90b08-da2e-40fa-bbb9-432b662d1872" />

- Setting 
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/d5e6eb5d-fc08-4d17-9735-ba1bcfe45762" />
<img width="680" height="226" alt="image" src="https://github.com/user-attachments/assets/304755a8-2377-4378-8963-334e5ee30c93" />


   ## Notes for the reviewer

   - Behavior change for all Linux users: "Use OS native controls" now defaults to off (it used to default to on), matching the window's `decorations: false` config. Users who want the OS frame can re-enable it.
   - The custom min/max/close buttons are hidden on Linux because the WM owns them there; tiling compositors like niri have no minimize at all.