### PR TITLE
Memory optimization, native audio engine, docs refresh

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,8 +5,8 @@ front end, bundled by Vite 7. No router and no Redux — plain classes with `use
 and direct Tauri IPC. The UI is built on Tailwind v4 plus animated components vendored from the
 [beUI](https://beui.dev) registry, with [Solar](https://solar-icons.vercel.app) icons.
 
-- Version: `1.2.81` (`package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json` are kept in lockstep)
-- Bundle id: `com.zuno.desktop`
+- Version: `1.2.1` (`package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json` are kept in lockstep)
+- Bundle id: `com.zuno.desktop` · Rust crate `zuno` / lib `zuno_lib`
 - Platforms: Windows, macOS, Linux
 - Companion docs: [frontend.md](./frontend.md) (UI), [backend.md](./backend.md) (Rust/IPC)
 
@@ -20,7 +20,7 @@ flowchart TB
     UI["React UI<br/>src/ui/**"]
     STATE["Controllers + stores<br/>src/player/**"]
     DS["DataSource layer<br/>src/datasource/**"]
-    IFRAME["Hidden YouTube IFrame player"]
+    IFRAME["Two hidden YouTube IFrame decks"]
   end
 
   subgraph Mini["mini-player window (mini.html → src/mini.tsx)"]
@@ -30,13 +30,16 @@ flowchart TB
   subgraph Rust["Tauri backend (src-tauri/src/**)"]
     CMD["Tauri commands"]
     CACHE["File cache (LRU)"]
+    OFF["Offline audio store"]
     SET["settings-v1.json"]
     KEY["OS keyring / encrypted session"]
-    HTTP["reqwest proxy + audio fetch"]
+    HTTP["reqwest proxy + cookie jar"]
     MEDIA["SMTC / MPNowPlayingInfoCenter"]
+    TRAY["Tray icon"]
     RPC["Discord IPC"]
     LFM["Last.fm API"]
     SRV["127.0.0.1 media server"]
+    WATCH["notify folder watcher"]
   end
 
   UI --> STATE --> DS
@@ -44,19 +47,23 @@ flowchart TB
   DS -->|invoke| CMD
   UI -->|invoke| CMD
   MP <-->|Tauri events| UI
-  CMD --> CACHE & SET & KEY & HTTP & MEDIA & RPC & LFM & SRV
+  CMD --> CACHE & OFF & SET & KEY & HTTP & MEDIA & TRAY & RPC & LFM & SRV & WATCH
   HTTP -->|HTTPS| YT["music.youtube.com / googlevideo.com"]
   IFRAME -->|audio| YT
 ```
 
-Three rules explain most of the design:
+Four rules explain most of the design:
 
 1. **All network traffic to Google goes through Rust** (`proxy_http_request`) so the WebView's
-   CORS/cookie rules never apply and cookie auth can be signed properly.
-2. **Audio is played by YouTube's own IFrame player**, not by `<audio>` — this dodges the 403s
-   that signed googlevideo URLs return when replayed from a different context. Native `<audio>`
-   is used only for local files and as a fallback path.
-3. **Every piece of durable state has two homes**: `localStorage` (synchronous, drives the UI)
+   CORS/cookie rules never apply, cookie auth can be signed properly, and rotated `Set-Cookie`
+   values can be merged back into the stored session.
+2. **Streaming audio is played by YouTube's own IFrame player**, not by `<audio>` — this dodges the
+   403s that signed googlevideo URLs return when replayed from a different context. Native `<audio>`
+   serves local files and *downloaded* tracks.
+3. **Downloads are a separate path from playback.** `offline_audio_save` fetches the same signed URL
+   in Rust with a PO token, in 4 MiB ranges, and stores the bytes on disk; playback of a downloaded
+   track then never touches the network.
+4. **Every piece of durable state has two homes**: `localStorage` (synchronous, drives the UI)
    and a Rust-owned JSON file (survives WebView data wipes). See §6.
 
 ---
@@ -65,28 +72,33 @@ Three rules explain most of the design:
 
 | Window | Label | Entry | Notes |
 |---|---|---|---|
-| Main | `main` | `index.html` → `src/main.tsx` | 1280×800, min 900×600, `decorations: false` (custom title bar; Linux forces decorations on at runtime) |
-| Mini player | `mini-player` | `mini.html` → `src/mini.tsx` | 160×80, transparent, always-on-top, `skipTaskbar`, hidden until the main window loses focus |
-| Sign-in | `youtube-music-login` | Google sign-in URL | Created on demand by Rust during `sign_in_youtube_music`, destroyed after the session cookie appears |
+| Main | `main` | `index.html` → `src/main.tsx` | 1280×900, min 900×600, `decorations: false`, `transparent: true`, `shadow: false` (custom title bar and window edge; Linux forces decorations on at runtime) |
+| Mini player | `mini-player` | `mini.html` → `src/mini.tsx` | transparent, always-on-top, `skipTaskbar`, shown when the main window is backgrounded or minimized |
+| Sign-in | `youtube-music-login` | Google sign-in URL | Created on demand by Rust during `sign_in_youtube_music` (and headlessly by `refresh_youtube_music_cookie`), destroyed after the session cookie appears |
 
 Vite is configured with two Rollup inputs (`vite.config.ts`), so main and mini ship as separate
-HTML entry points sharing the same module graph.
+HTML entry points sharing the same module graph. `@` is aliased to `src/`.
 
 **Production frontend hosting is unusual.** In release builds `run()` picks a free port, serves
 `dist/` through `tauri-plugin-localhost`, and rewrites `frontend_dist` to `http://localhost:<port>`.
 The YouTube IFrame API refuses to run under the `tauri://` / `asset://` origins, so the app needs a
 real `http://` origin. Dev builds use the normal Vite dev server on port 1420.
 
-**Window events → frontend:**
+**Rust → frontend events:**
 
 | Event | Emitted when | Consumed by |
 |---|---|---|
 | `main-window-backgrounded` | main window loses focus and mini player isn't focused (100 ms debounce) | `App.tsx` — shows the mini player |
+| `main-window-minimized` | same check, but the window turned out to be minimized | `App.tsx` — shows the mini player even during drag suppression |
 | `window-focused` | main window regains focus | `App.tsx` — hides the mini player, triggers connection recovery |
-| `windows-media-control` | SMTC button pressed | `useMediaSession` |
+| `windows-media-control` | SMTC or taskbar thumbnail button pressed | `useMediaSession` |
+| `offline-download-progress` | per-chunk progress during `offline_audio_save` | `player/offlineStore.ts` |
+| `local-audio-changed` | `notify` watcher sees a change under a watched music folder | `main.tsx` → `notifyLocalPlaylistsChanged()` |
 
-Mini ↔ main communication is a set of plain Tauri events (`emit`/`listen`) carrying player status,
-time, and volume snapshots; the mini window holds no controllers of its own.
+**Mini ↔ main** is a set of plain Tauri events, no shared controllers:
+main emits `player-state-sync` / `player-time-sync` / `player-volume-sync`; the mini window emits
+`mini-player:request-sync`, `:toggle-play-pause`, `:skip-next`, `:skip-previous`, `:seek`,
+`:volume`, `:position-changed`, `:restore-main`.
 
 ---
 
@@ -95,9 +107,9 @@ time, and volume snapshots; the mini window holds no controllers of its own.
 ```
 src/
 ├─ main.tsx / mini.tsx      bootstrap: settings hydration, error hooks, React root
-├─ internal/                cross-cutting: cache, app settings, logging, updater
+├─ internal/                cross-cutting: cache, app settings, logging, updater, equality helpers
 ├─ datasource/              "where does music come from" — abstract API + YouTube Music impl
-├─ player/                  playback engine, queue, tabs, library, integrations
+├─ player/                  playback engine, queue, tabs, library, offline, integrations
 ├─ components/              vendored beUI primitives (registry paths, do not restructure)
 ├─ lib/                     beUI helpers: cn, ease tokens, use-hover-capable
 └─ ui/                      app components, pages, settings modules, stores, icons.tsx
@@ -106,32 +118,51 @@ src/
 Dependency direction is strictly downward: `ui → player → datasource → internal → Tauri IPC`.
 Nothing in `datasource/` imports from `ui/`.
 
+Alongside the source, `*.check.ts` files hold executable assertions for the non-trivial pure logic
+(queue moves, lyric timing, artwork picking, translation parsing, playlist transfer, prop equality,
+…). `npm run check` bundles and runs each in its own process — see §8.
+
 ### 3.1 `internal/` — cross-cutting utilities
 
 | Module | Responsibility |
 |---|---|
 | `cache.ts` | Thin wrapper over the Rust file cache (`cache_get/set/stats/clear`). JSON in, JSON out. Default budget 4 GiB. |
 | `appSettings.ts` | `app_setting_get/set/remove` + `app_settings_clear`. Never throws (except `clear`). |
-| `durableLocalSetting.ts` | The localStorage ⇄ durable-settings mirroring helpers (`readLocal*`, `writeLocal*`, `hydrateLocal*`). Every settings module in `ui/settings/` is built on these. |
+| `durableLocalSetting.ts` | The localStorage ⇄ durable-settings mirroring helpers (`read/write/hydrateLocal{Boolean,Json}Setting`). Every settings module in `ui/settings/` is built on these. |
 | `logging.ts` | `logInternalDebug/Info/Warn/Error`. Redacts cookies, tokens, authorization headers and full URLs before forwarding to Rust via `frontend_log`, then also mirrors to the console. |
 | `updateChecker.ts` | `tauri-plugin-updater` wrapper; on macOS it degrades to a GitHub Releases API check (notify-only, no in-app install). 24 h per-version snooze in localStorage. |
+| `releaseNote.ts` | The one-time "what's new" note, keyed to the installed version rather than a flag. |
+| `artworkCache.ts` | Remembers which artwork candidate URL actually loaded, per source URL, so remounts don't rewalk the fallback chain. Hydrated before React mounts. |
+| `audioQuality.ts` | Streaming and download quality caps, set independently. |
+| `lyricsSourcePreference.ts` | Which lyric provider is promoted to the front of the race. A preference, not a restriction. |
+| `base64.ts` | Byte-oriented base64 for binary payloads crossing IPC (`btoa` is Latin-1 only). |
+| `shallowEqual.ts` / `propsEqual.ts` | One-level equality for store selectors and for `memo` on components handed inline arrows. |
 
 ### 3.2 `datasource/` — content abstraction
 
 `DataSource` (`datasource/DataSource.ts`) is an abstract class where *everything except
 `getTrack` and `getStreamUrl` is optional*. Controllers feature-detect (`this.dataSource.getLyrics?.(…)`),
-so a partial implementation degrades gracefully instead of crashing.
+so a partial implementation degrades gracefully instead of crashing. The optional surface now covers
+search, link resolution, session lifecycle, multi-account (`listAccounts` / `selectAccount`),
+library, albums, artists (subscribe, notification level), playlists (create/rename/describe/delete/
+reorder/add/remove), likes and ratings, notifications, recommendations, related shelves, browse
+pages, and lyrics.
 
 Domain types live in `datasource/types.ts`: `Track`, `Album`, `Playlist`, `Artist`, `ArtistPage`,
-`SearchResults`, `TrackPage`, `Lyrics`, `LibrarySnapshot`, `AuthPrompt`. `Track.source` is
+`SearchResults`, `TrackPage`, `Lyrics`, `BrowsePage`/`BrowseShelf`/`BrowseTarget`, `FeedNotification`,
+`AccountOption`/`AccountProfile`, `AuthPrompt`/`AuthProgress`, `LibrarySnapshot`. `Track.source` is
 `"youtube" | "local"` — the single discriminator that routes local files down a different
 playback path.
 
 | File | Role |
 |---|---|
-| `youtube/YouTubeMusicDataSource.ts` | **The only implementation wired up.** ~4.2k lines. Owns Innertube clients, library/playlist/album/artist fetching, search, recommendations, likes, lyrics, and stream resolution. |
+| `youtube/YouTubeMusicDataSource.ts` | **The only implementation wired up.** ~6.1k lines. Owns Innertube clients, library/playlist/album/artist fetching, browse surfaces, search, recommendations, likes, ratings, notifications, accounts, lyrics, and stream resolution. |
 | `youtube/tauriFetch.ts` | `fetch`-shaped adapter that funnels youtubei.js through `proxy_http_request`. Computes the `SAPISIDHASH` authorization header, sets `origin`/`referer` to `music.youtube.com`, and rewrites `www.youtube.com/youtubei/*` → `music.youtube.com` when the client id is `67` (YouTube Music). |
+| `youtube/poToken.ts` | Proof-of-Origin token minting via `bgutils-js`. Signed googlevideo URLs are only served to a session that can prove it came from a real browser; without it the second and later downloads 403. |
+| `youtube/lyricsSources.ts` | The provider table. Sources are grouped into waves: wave 1 is raced in parallel, wave 2 (the expensive YouTube calls) only runs if wave 1 came back empty. Per-source `timeoutMs` and a `LyricsSourceAttempt` trail for the UI. |
+| `youtube/links.ts` | Parses a pasted YouTube / YouTube Music URL without a network round-trip; returns null for the shapes that genuinely need the API (`@handles`, `youtu.be` redirects, vanity channels). |
 | `youtube/artwork.ts` | Walks arbitrary Innertube response objects collecting `{url,width,height}` candidates and picks the largest; plus `i.ytimg.com` fallbacks by video id. |
+| `translate.ts` | Lyric translation through Google's keyless `translate_a` endpoint. Every failure is normal: a miss returns null and the caller shows the original words. |
 | `youtube/YouTubeDataSource.ts` | **Dead code.** Older non-Music implementation, no longer imported anywhere (see §9). |
 
 Caching inside the data source is a consistent stale-while-revalidate pattern:
@@ -149,17 +180,21 @@ Cache keys are versioned strings (`youtube-music:library:v5`, `youtube-music:tra
 
 | Module | Responsibility |
 |---|---|
-| `AudioEngine.ts` | Owns one hidden YouTube IFrame player (200×200, `opacity: 0.01`, `pointer-events: none`) plus an optional `HTMLAudioElement`. Handles cue/play state machines with timeouts and per-request cancellation. A module-level `playbackClaimId` + `playbackOwner` pair guarantees only one engine makes sound at a time. |
-| `Queue.ts` | Pure queue data structure with three regions: played/current, a **manual queue** segment (`playNext` / `addToQueue`), and automatic upcoming tracks. Shuffle only touches the automatic region and remembers the original order so it can be restored. |
-| `PlayerController.ts` | One per tab. Orchestrates DataSource → AudioEngine → Queue, playback order modes (`in-order` / `shuffle` / `repeat-one`), radio/autoplay refills, history, error surfacing, session export/restore, and Discord presence updates. |
+| `AudioEngine.ts` | Owns **two** hidden YouTube IFrame decks plus an optional `HTMLAudioElement`. The standby deck holds the *next* track already cued, which is what makes transitions gapless; with a non-zero crossfade the two decks' volumes are ramped past each other. A module-level `playbackClaimId` + `playbackOwner` pair guarantees only one engine makes sound at a time; an idle standby is freed after a timeout. |
+| `Queue.ts` | Pure queue data structure with three regions: played/current, a **manual queue** segment (`playNext` / `addToQueue`), and automatic upcoming tracks. Shuffle only touches the automatic region and remembers the original order so it can be restored. `move()` rejects cross-region moves. |
+| `PlayerController.ts` | One per tab. Orchestrates DataSource → AudioEngine → Queue, playback order (shuffle and repeat compose independently), crossfade/gapless settings, playback rate, stop-after-track, radio/autoplay refills, history, error surfacing, session export/restore, and Discord presence updates. |
 | `TabManager.ts` | Owns the `Map<tabId, PlayerController>`. Distinguishes the **focused** tab (what you're looking at) from the **playback owner** (what's making sound), and suspends/resumes engines on switch. |
-| `playerStore.ts` | Composition root: constructs the data source and the three controllers, restores the persisted session, and exposes `usePlayerState` / `usePlayerSession` / `useLibraryState` hooks plus an `ActivePlayerController` facade that always targets the right tab. |
-| `LibraryController.ts` | Sign-in/out, library snapshot loading with a 20 s timeout and post-sign-in retries, optimistic like/save mutations with rollback, and local-playlist merging. |
+| `playerStore.ts` | Composition root: constructs the data source and the three controllers, restores the persisted session, and exposes `usePlayerState` / `usePlayerSelector` / `usePlayerSession` / `useLibraryState` plus an `ActivePlayerController` facade that always targets the right tab. |
+| `LibraryController.ts` | Sign-in/out, account switching, staged auth progress (`browser → session → library`), library snapshot loading with timeouts and post-sign-in retries, silent session recovery, optimistic like/rating mutations with rollback, and local-playlist merging. |
 | `SearchController.ts` | Trims queries, falls back from `search` to `searchTracks`, forwards streaming `onUpdate` callbacks. |
-| `localPlaylists.ts` | Local-file playlists: folder paths, per-playlist added tracks, ordering — all in localStorage, resolved through `local_audio_scan`. |
+| `offlineStore.ts` | Download queue and manifest. Statuses `absent → queued → downloading → ready \| failed`, a byte ceiling (default 8 GiB), progress fed by the `offline-download-progress` event, and `useOfflineState()` for the UI. |
+| `playHistory.ts` | Local play log (500 entries, oldest trimmed) behind the History page. A replay inside a short window updates the existing entry instead of appending. |
+| `localPlaylists.ts` | Local-file playlists: folder paths, per-playlist added tracks, ordering — all in localStorage, resolved through `local_audio_scan`, kept live by the folder watcher. |
+| `playlistMembership.ts` | Remembers which playlists a track is in (1000 tracks, pruned oldest-first) so the context menu can render without a round-trip. |
+| `playlistTransfer.ts` | Versioned JSON export/import of playlists. |
 | `recentPlaylists.ts` | Last-played timestamps per playlist for sidebar ordering. |
-| `playbackSettings.ts` | Volume/mute, mirrored to durable settings. |
-| `appSession.ts` | Whole-app session snapshot in localStorage (`yt-music-dock.app-session.v1`): tabs + per-tab player sessions. Restores `playing` as `paused` so launching the app never autoplays. |
+| `playbackSettings.ts` | Volume/mute, playback rate, crossfade seconds, gapless flag — mirrored to durable settings. |
+| `appSession.ts` | Whole-app session snapshot in localStorage: tabs + per-tab player sessions. Restores `playing` as `paused` so launching the app never autoplays. Honours the "restore tabs and queues" setting. |
 | `DiscordRPC.ts` | Sanitizes presence payloads (128-char text limit, HTTPS-only artwork from a trusted host allowlist) before invoking Rust. |
 | `LastFm.ts` | Tracks listened seconds, sends `nowPlaying` once per track and scrobbles at `min(240 s, duration/2)`; tracks shorter than 31 s never scrobble. |
 | `useMediaSession.ts` | Bridges player state to Windows SMTC (via `update_windows_media_session` + `windows-media-control` events) or, elsewhere, the WebView `navigator.mediaSession`. |
@@ -170,7 +205,8 @@ Cache keys are versioned strings (`youtube-music:library:v5`, `youtube-music:tra
 
 Detailed in [frontend.md](./frontend.md). Summary: `App.tsx` is the single stateful root
 (tabs, navigation history, onboarding, updates, window/mini-player wiring, global shortcuts);
-everything else is presentational or reads a store hook directly.
+every page below it is `lazy`-loaded, and everything else is presentational or reads a store hook
+directly.
 
 ### 3.5 `src-tauri/src/` — Rust
 
@@ -179,7 +215,7 @@ Detailed in [backend.md](./backend.md).
 | File | Responsibility |
 |---|---|
 | `main.rs` | Sets the Windows AppUserModelID, strips the WebView2 diagnostics env var, calls `run()` |
-| `lib.rs` (~2.4k lines) | Commands, cache, settings, logging, keyring/session, HTTP proxy, audio fetch, local media server, window event wiring |
+| `lib.rs` (~3.8k lines) | Commands, cache, settings, logging, keyring/session + cookie jar, HTTP proxy, audio fetch, offline store, local files and tags, folder watcher, media server, tray, window event wiring |
 | `discord_rpc.rs` | `DiscordIpcClient` lifecycle and activity building |
 | `lastfm.rs` | MD5-signed Last.fm API calls, session in keyring |
 | `windows_media.rs` | SMTC integration + taskbar thumbnail toolbar buttons |
@@ -193,15 +229,19 @@ Detailed in [backend.md](./backend.md).
 
 ```
 main.tsx
+  hydrateArtworkCache()              → before paint, so no fallback-icon flash
   applyPlatformAttributes()          → data-platform-linux on <html>
+  applyTheme() + watchSystemTheme()  → data-theme; "system" keeps following the OS
   applyPaperPcMode()                 → data-paper-pc (reduced-motion / no blur theme)
   applyNativeWindowControls()        → window decorations on/off
   hydrateMainWindowGeometry() → restoreMainWindowGeometry()
-  Promise.all([ hydrate* for paperPc, windowControls, miniPlayer, playerControls,
-                lastFm, keyboardShortcuts, playbackSettings ])
+  Promise.all([ ~17 hydrate* calls: paperPc, theme, windowControls, miniPlayer, playerControls,
+                queuePanel, tray, audioQuality, lastFm, discord, sidebar, keyboardShortcuts,
+                toolbarItems, homeSections, playbackSettings, playHistory, sessionRestore ])
   DiscordRpcService.init()
   window error / unhandledrejection hooks
-  ReactDOM.createRoot(...).render(<App/>)
+  createRoot().render(<StrictMode><ErrorBoundary><App/></ErrorBoundary></StrictMode>)
+  syncLocalAudioWatcher() + listen("local-audio-changed")
 
 playerStore.ts (module side effect, imported by App)
   new YouTubeMusicDataSource()
@@ -227,17 +267,19 @@ UI onClick
        queue.set(playbackQueue, startIndex)          isPlaylistMode = queue>1 && !autoplay
        dataSource.getTrack(videoId)                  cached, merged with the queued row
        ensureTrackLoaded(track)
-          local  → getStreamData() → local_audio_read → <audio> via loadNativeFallback
-          remote → audioEngine.loadTrack(videoId)  → IFrame cueVideoById + wait for CUED
+          local / downloaded → local_audio_read | offline_audio_source → <audio>
+          remote             → audioEngine.loadTrack(videoId) → deck cueVideoById, wait for CUED
        audioEngine.play()                            claims global playback, waits for PLAYING
-       setState({status:"playing"})
-  → emit() → React re-render + Discord presence update
+       setState({status:"playing"}) → recordPlay(track)
+  → emit() → React re-render + Discord presence + Last.fm nowPlaying
 ```
 
-Track end (`onEnded`) → `handleTrackEnded`: repeat-one replays; otherwise the next queue item;
-otherwise queue-end recommendations (playlist mode); otherwise the radio queue if autoplay is on;
-otherwise pause. `refillAutomaticQueue()` tops the automatic region back up when fewer than 10
-tracks remain and the queue isn't a fixed playlist.
+Ahead of the end of a track the engine cues the next one onto the **standby deck**. Track end
+(`onEnded`) then hands over: with `crossfadeSec` at 0 the swap is gapless; above 0 the two decks'
+volumes ramp past each other. Repeat-one replays instead; otherwise the next queue item; otherwise
+queue-end recommendations (playlist mode); otherwise the radio queue if autoplay is on; otherwise
+pause. `refillAutomaticQueue()` tops the automatic region back up when fewer than 10 tracks remain
+and the queue isn't a fixed playlist.
 
 Every async step is guarded by a monotonically increasing request id (`playTrackRequestId`,
 `radioQueueRequestId`, `loadRequestId`), so a fast skip cancels the in-flight work rather than
@@ -247,13 +289,16 @@ letting a stale response overwrite state.
 
 | Track kind | Path |
 |---|---|
-| YouTube, normal | No stream URL is fetched at all — the IFrame player handles it from the video id. |
-| YouTube, native fallback (`getStreamData`) | Innertube `getBasicInfo` → best `audio/mp4` adaptive format → decipher → `fetch_audio_source` downloads it in Rust, verifies the `ftyp` box, and re-serves it from a local `127.0.0.1` HTTP server so the WebView can stream it without CORS or signed-URL issues. |
+| YouTube, streaming | No stream URL is fetched at all — the IFrame deck handles it from the video id. |
+| YouTube, downloaded | `offline_audio_source` serves the stored bytes from the local `127.0.0.1` media server, with Range support. No network. |
+| YouTube, download | `getStreamData` → Innertube `getBasicInfo` → best adaptive `audio/mp4` at the configured quality → decipher → PO token → `offline_audio_save` fetches it in 4 MiB ranges, 6 at a time, emitting progress. |
+| YouTube, native fallback | `fetch_audio_source` downloads once, validates the MP4 `ftyp` box, and re-serves it from the media server. |
 | Local file | `local_audio_read` returns base64 bytes + a MIME type guessed from the extension; the frontend builds a `Blob` object URL. |
 
-`shouldUseNativeAudio()` currently returns `false` unconditionally — the native path is reachable
-only via `loadNativeFallback` (local files). The comment in `AudioEngine.ts` records why: the
-backend download path returned 403s, so v1.2.65 reverted every platform to the IFrame player.
+`shouldUseNativeAudio()` returns `false` unconditionally — for *streaming* YouTube tracks the
+native path stays off. The comment in `AudioEngine.ts` records why: the backend download path
+returned 403s, so v1.2.65 reverted every platform to the IFrame player. The PO token work since
+then is what made the download path viable, and downloads use it.
 
 ### 4.4 Authentication
 
@@ -267,24 +312,38 @@ signIn()
       polls once a second, up to 300 s, for cookies on music.youtube.com
       success = has SAPISID|__Secure-1PAPISID|__Secure-3PAPISID AND the window is on music.youtube.com
       serializes them into one Cookie header, persists, closes the window, returns the header
-  → frontend clears the data cache, rebuilds the Innertube client, refreshes the library
+  → frontend clears the data cache (unless it's the same account), rebuilds the Innertube
+    client, refreshes the library
 ```
+
+`LibraryController` reports the stages — `browser`, `session`, `library` — through `authProgress`,
+so the overlay can tell "waiting on a browser window" apart from "fetching your library".
+`cookie_account_identity()` compares the `SAPISID` across a re-sign-in: the same account keeps its
+cache, a different one drops it.
+
+**Keeping the session alive.** Google rotates session cookies continuously. Every proxied response
+from a YouTube host has its `Set-Cookie` headers merged into a Rust-side cookie jar
+(`apply_set_cookie`): a rotated value replaces the stale one, a tombstone drops it, an unchanged
+value writes nothing. Credential rotations persist immediately; the noisy `SIDCC` family may wait
+for a 5-minute interval. `refresh_youtube_music_cookie` re-mints a lapsed session in a hidden window
+without user interaction.
 
 Storage differs by OS: Windows/Linux split the header into ≤900-byte chunks across up to 16 keyring
 entries plus a `chunks:<n>` manifest (keyrings cap entry size); macOS encrypts the header with
 AES-256-GCM into `youtube-music-session-v1.bin` under the app data dir and keeps only the 32-byte
 key in the keychain. The keyring service name is still the legacy `com.ytmusicdock.app` so existing
-sign-ins survived the rename.
+sign-ins survived the rename, and `migrate_legacy_app_data` copies over data from the older
+`com.justanothermusicclient.desktop` identifier on first run.
 
-After sign-in `LibraryController` retries the library fetch up to three times (0 / 1.5 s / 5 s)
-because YouTube's library endpoints briefly return empty right after the session is created.
-
-### 4.5 Search
+### 4.5 Search and browse
 
 `SearchOverlay` (Ctrl/⌘+K) does three things at once: fuzzy-matches your own playlists and albums
 locally, requests `getSearchSuggestions`, and on submit opens a `search` view (optionally in a new
-tab). `SearchResultsPage` renders the mixed `SearchResults` (artists / tracks / albums / playlists),
-with streaming `onUpdate` callbacks painting partial results as they arrive.
+tab). A pasted YouTube link is recognised by `looksLikeYouTubeLink` and resolved instead of searched.
+`SearchResultsPage` renders the mixed `SearchResults` with streaming `onUpdate` callbacks painting
+partial results as they arrive. `BrowsePage` renders the non-search discovery surfaces
+(`explore` / `charts` / `moods` / `podcasts`) through `getBrowsePage`, and `RelatedPage` renders
+`getRelated` shelves for a single track.
 
 ---
 
@@ -293,8 +352,10 @@ with streaming `onUpdate` callbacks painting partial results as they arrive.
 No state library. Three patterns, in order of preference:
 
 1. **Class + listener set + `useSyncExternalStore`** — `TabManager`, `LibraryController`,
-   `playerUIStore`. Subscribers get a `getSnapshot` that must return a stable reference; controllers
-   cache their snapshot (`activeSessionSnapshot`) and invalidate it on `emit()`.
+   `playerUIStore`, `ambientArtworkStore`, `offlineStore`. Subscribers get a `getSnapshot` that must
+   return a stable reference; controllers cache their snapshot and invalidate it on `emit()`.
+   `usePlayerSelector` narrows that with `shallowEqual` so a component only re-renders for the
+   fields it read.
 2. **localStorage + custom `window` event + `useSyncExternalStore`** — every module under
    `ui/settings/`. The event name (e.g. `mini-player-enabled-change`) is the change channel, and the
    `storage` event covers the other window.
@@ -315,14 +376,15 @@ while `loadTrack`/`playTrackById` first *claim* the focused tab as the new owner
 
 | Store | Location | Contents |
 |---|---|---|
-| Durable app settings | `<app_data_dir>/settings-v1.json` (Rust, mutex-guarded) | Mirror of every UI setting: theme flags, shortcuts, window geometry, mini-player position, sidebar order, onboarding flags |
-| localStorage | WebView profile | Same settings (fast path) + session, local playlists, recent playlists, recent searches, update snoozes |
-| Data cache | `<app_cache_dir>/data-cache-v1/entries/<fnv1a>.json` | Library, playlists, albums, artists, tracks, lyrics, search results. LRU-evicted to a configurable budget (default 4 GiB) |
+| Durable app settings | `<app_data_dir>/settings-v1.json` (Rust, mutex-guarded) | Mirror of every UI setting: theme, shortcuts, window geometry, mini-player position, sidebar mode, toolbar/home-section toggles, audio quality, tray, onboarding flags |
+| localStorage | WebView profile | Same settings (fast path) + session, play history, local playlists, playlist membership, offline manifest, recent playlists, recent searches, update snoozes |
+| Data cache | `<app_cache_dir>/data-cache-v1/entries/<fnv1a>.json` | Library, playlists, albums, artists, tracks, browse pages, lyrics, search results. LRU-evicted to a configurable budget (default 4 GiB) |
+| Offline audio | `<app_data_dir>/offline-audio-v1/<trackId>.bin` | Downloaded track bytes. The frontend keeps the metadata manifest in localStorage and reconciles it against `offline_audio_list`. Pruned oldest-first to a configurable ceiling (default 8 GiB) |
 | Secrets | OS keyring (`com.ytmusicdock.app`) — plus an AES-GCM file on macOS | YouTube cookie header, Last.fm session key |
 | Logs | `<app_log_dir>/current.log` | Truncated on every launch; older `*.log` files deleted |
 
-"Delete all app data" in Settings clears all five: `clearAppSettings()`, `clearCache()`,
-`clearAppSession()`, `localStorage.clear()`, plus sign-out.
+"Delete all app data" in Settings clears them: `clearAppSettings()`, `clearCache()`,
+`clearAppSession()`, `removeAllDownloads()`, `localStorage.clear()`, plus sign-out.
 
 ---
 
@@ -330,33 +392,52 @@ while `loadTrack`/`playTrackById` first *claim* the focused tab as the new owner
 
 | Integration | Where | Notes |
 |---|---|---|
-| Discord Rich Presence | `player/DiscordRPC.ts` → `discord_rpc_update` / `_clear` → `discord_rpc.rs` | Client id `1515682467154100344`. Timestamps derived from position so Discord shows a live progress bar. Artwork is forced to `i.ytimg.com/vi/<id>/hqdefault.jpg` for YouTube tracks because Google CDN hosts block Discord's fetcher. |
+| Discord Rich Presence | `player/DiscordRPC.ts` → `discord_rpc_update` / `_clear` → `discord_rpc.rs` | Client id `1515682467154100344`. Timestamps derived from position so Discord shows a live progress bar. Artwork is forced to `i.ytimg.com/vi/<id>/hqdefault.jpg` for YouTube tracks because Google CDN hosts block Discord's fetcher. Toggleable (`ui/settings/discord.ts`). |
 | Last.fm | `player/LastFm.ts` → `lastfm_*` → `lastfm.rs` | Desktop auth-token flow opened in the system browser; session key in the keyring; MD5 `api_sig` computed in Rust. |
 | Windows SMTC | `windows_media.rs` | `MediaPlayer`/`SystemMediaTransportControls` for the OS overlay, plus taskbar thumbnail toolbar buttons. Sends `windows-media-control` events back to JS. |
 | macOS Now Playing | `macos_media.rs` | `MPNowPlayingInfoCenter` via `objc2`. Requires `macOSPrivateApi: true`. |
 | Other platforms | `useMediaSession.ts` | Falls back to `navigator.mediaSession` with metadata, position state, and action handlers. |
+| Tray icon | `lib.rs` `build_tray()` | Always built so the setting takes effect without a restart. With "minimize to tray" on, closing the main window hides it and playback continues; the tray menu restores or quits. |
+| Local folder watching | `lib.rs` `local_audio_watch` (`notify`) | Emits `local-audio-changed` with no detail — a rescan is cheap and diffing renames/temp files would be far more code for the same result. |
 | Autostart | `ui/settings/autostart.ts` | `tauri-plugin-autostart`. |
 | Updates | `internal/updateChecker.ts` | `tauri-plugin-updater`, minisign-signed, endpoints on GitHub Releases (`latest.json`) and an `updater-channel` branch. macOS is notify-only. |
 
 ---
 
-## 8. Build, release, security
+## 8. Build, test, release, security
 
 **Build:** `npm run dev` (Vite only) · `npm run tauri dev` · `npm run tauri build`
 (runs `tsc && vite build` first via `beforeBuildCommand`). Bundle targets: `all`,
-with updater artifacts enabled. CI lives in `.github/workflows/release.yml`.
+with updater artifacts enabled. Linux AppImage bundles the media framework; the RPM declares
+webkit2gtk4.1 / gtk3 / libayatana-appindicator and recommends the GStreamer plugin sets.
+
+**Checks:** `npm run typecheck` (`tsc --noEmit`) and `npm run check` — the latter runs
+`scripts/run-checks.mjs`, which finds every `*.check.ts` under `src/`, bundles it with esbuild's JS
+API and runs each in its own process with a 30 s timeout. `npm run verify` is both. The Rust side
+has a `#[cfg(test)]` module in `lib.rs` (`cargo test`). There is no component/DOM test harness.
+
+**Repo layout beyond the app:** `landing/` is a separate Vite site for the product page,
+`packaging/` holds the AUR PKGBUILD and the Flatpak manifest, `manifests/` holds the winget
+submission. Workflows: `ci.yml`, `release.yml`, `aur.yml`, `flatpak.yml`.
 
 **Security posture:**
 
 - `app.security.csp` is `null` — no CSP is enforced. Needed because the app loads the YouTube
   IFrame API from `youtube.com` at runtime; worth revisiting if that path ever changes.
-- `src-tauri/capabilities/default.json` allowlists every command and window permission explicitly.
-  A new `#[tauri::command]` must be added there or the frontend can't call it.
+- `src-tauri/capabilities/default.json` allowlists core and plugin permissions per window. Note its
+  `command.allow` / `allowlist` blocks are Tauri 1 syntax and no longer gate anything (see
+  [backend.md](./backend.md) §4) — they are stale relative to `generate_handler!`.
 - Log sanitization happens twice: `internal/logging.ts` redacts before sending, and Rust's
-  `sanitize_log_message` redacts again before writing to disk.
+  `sanitize_log_message` / `sanitize_log_url` redact again before writing to disk. The URL
+  sanitizer keeps the diagnostic params (`expire`, `itag`, `c`, `cver`, `clen`) and replaces
+  signatures with a `[9ch]`-style length marker.
 - Discord and artwork URLs are validated against host allowlists before leaving the app.
+- The cookie jar only accepts `Set-Cookie` from YouTube hosts — a suffix match alone would hand the
+  session to a lookalike domain, which is what `is_youtube_cookie_host` guards.
 - Signed `googlevideo.com` URLs carry an `ip=` parameter; the Rust client binds its local address
   to the matching IP family so the signature stays valid.
+- `local_audio_read` / `local_audio_write_tags` re-validate the path and extension rather than
+  trusting the frontend.
 
 ---
 
@@ -366,9 +447,17 @@ Recorded so nobody re-derives them:
 
 - `src/datasource/youtube/YouTubeDataSource.ts` (809 lines) — superseded by `YouTubeMusicDataSource`, not imported.
 - `src/player/Recommender.ts` — stub returning `[]`, not imported. Recommendations live in the data source.
-- `src/ui/components/player/ExpandedPlayerBar.tsx` — migrated to Tailwind so it compiles, but its
-  render block is still commented out in `App.tsx`; the `isExpandedPlayerBar` state and toggle are live.
-- `greet` command in `lib.rs` — Tauri scaffolding leftover, still allowlisted.
-- `AudioEngine.shouldUseNativeAudio()` is hardcoded `false`; the native/`fetch_audio_source` path and `fetch_youtube_music_audio` exist but are only reachable for local files.
-- `App.tsx` is 1717 lines with ~25 `useEffect` blocks, several written at zero indentation (lines 1340+) — the highest-value refactor target in the repo.
-- `getStreamUrl` on the YouTube Music data source is required by the abstract class but never called by the controllers.
+- `src/ui/components/MagicDice.tsx` — not imported; `DiceCard.tsx` is the live one.
+- `src/ui/components/player/ExpandedPlayerBar.tsx` — its render block is still commented out in
+  `App.tsx` (~line 1954); the `isExpandedPlayerBar` state and toggle are live and do nothing visible.
+- `greet` command in `lib.rs` — Tauri scaffolding leftover, still registered.
+- `capabilities/default.json` `command.allow` — Tauri 1 leftover; missing every command added since
+  (all `offline_audio_*`, `read_text_file`, `write_text_file`, `local_audio_*_tags`,
+  `local_audio_watch`/`unwatch`, `refresh_youtube_music_cookie`, `open_current_log`) and nothing
+  broke, which is the proof it is inert.
+- `AudioEngine.shouldUseNativeAudio()` is hardcoded `false`; the native streaming path exists but is
+  reachable only for local and downloaded files.
+- `App.tsx` is 2161 lines with ~30 `useEffect` blocks, some at zero indentation — still the
+  highest-value refactor target in the repo.
+- `getStreamUrl` on the YouTube Music data source is required by the abstract class but never called
+  by the controllers.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,7 +20,7 @@ flowchart TB
     UI["React UI<br/>src/ui/**"]
     STATE["Controllers + stores<br/>src/player/**"]
     DS["DataSource layer<br/>src/datasource/**"]
-    IFRAME["Two hidden YouTube IFrame decks"]
+    IFRAME["Two hidden IFrame decks<br/><i>or</i> an &lt;audio&gt; element"]
   end
 
   subgraph Mini["mini-player window (mini.html → src/mini.tsx)"]
@@ -57,9 +57,12 @@ Four rules explain most of the design:
 1. **All network traffic to Google goes through Rust** (`proxy_http_request`) so the WebView's
    CORS/cookie rules never apply, cookie auth can be signed properly, and rotated `Set-Cookie`
    values can be merged back into the stored session.
-2. **Streaming audio is played by YouTube's own IFrame player**, not by `<audio>` — this dodges the
-   403s that signed googlevideo URLs return when replayed from a different context. Native `<audio>`
-   serves local files and *downloaded* tracks.
+2. **There are two playback engines and the user picks one** (`ui/settings/audioEngine.ts`).
+   `iframe` (the default) hands the video id to a hidden YouTube IFrame player, dodging the 403s
+   that signed googlevideo URLs return when replayed from a different context — at the cost of a
+   `youtube.com` subframe process, roughly 90 MB. `native` resolves and downloads the track through
+   Rust and plays it from an `<audio>` element, with no subframe at all. Local and downloaded
+   tracks always take the native path regardless of the setting.
 3. **Downloads are a separate path from playback.** `offline_audio_save` fetches the same signed URL
    in Rust with a PO token, in 4 MiB ranges, and stores the bytes on disk; playback of a downloaded
    track then never touches the network.
@@ -73,7 +76,7 @@ Four rules explain most of the design:
 | Window | Label | Entry | Notes |
 |---|---|---|---|
 | Main | `main` | `index.html` → `src/main.tsx` | 1280×900, min 900×600, `decorations: false`, `transparent: true`, `shadow: false` (custom title bar and window edge; Linux forces decorations on at runtime) |
-| Mini player | `mini-player` | `mini.html` → `src/mini.tsx` | transparent, always-on-top, `skipTaskbar`, shown when the main window is backgrounded or minimized |
+| Mini player | `mini-player` | `mini.html` → `src/mini.tsx` | transparent, always-on-top, `skipTaskbar`. **Created on first show and destroyed when the main window regains focus** — a hidden webview keeps its whole renderer process (~32 MB), so only destroying returns it. Create and destroy are serialized against each other in `miniPlayer.ts`, because alt-tab fires blur and focus within milliseconds. |
 | Sign-in | `youtube-music-login` | Google sign-in URL | Created on demand by Rust during `sign_in_youtube_music` (and headlessly by `refresh_youtube_music_cookie`), destroyed after the session cookie appears |
 
 Vite is configured with two Rollup inputs (`vite.config.ts`), so main and mini ship as separate
@@ -88,9 +91,9 @@ real `http://` origin. Dev builds use the normal Vite dev server on port 1420.
 
 | Event | Emitted when | Consumed by |
 |---|---|---|
-| `main-window-backgrounded` | main window loses focus and mini player isn't focused (100 ms debounce) | `App.tsx` — shows the mini player |
-| `main-window-minimized` | same check, but the window turned out to be minimized | `App.tsx` — shows the mini player even during drag suppression |
-| `window-focused` | main window regains focus | `App.tsx` — hides the mini player, triggers connection recovery |
+| `main-window-backgrounded` | main window loses focus and mini player isn't focused (100 ms debounce) | `App.tsx` — creates and shows the mini player window |
+| `main-window-minimized` | same check, but the window turned out to be minimized | `App.tsx` — creates and shows it even during drag suppression |
+| `window-focused` | main window regains focus | `App.tsx` — destroys the mini player window, triggers connection recovery |
 | `windows-media-control` | SMTC or taskbar thumbnail button pressed | `useMediaSession` |
 | `offline-download-progress` | per-chunk progress during `offline_audio_save` | `player/offlineStore.ts` |
 | `local-audio-changed` | `notify` watcher sees a change under a watched music folder | `main.tsx` → `notifyLocalPlaylistsChanged()` |
@@ -180,7 +183,7 @@ Cache keys are versioned strings (`youtube-music:library:v5`, `youtube-music:tra
 
 | Module | Responsibility |
 |---|---|
-| `AudioEngine.ts` | Owns **two** hidden YouTube IFrame decks plus an optional `HTMLAudioElement`. The standby deck holds the *next* track already cued, which is what makes transitions gapless; with a non-zero crossfade the two decks' volumes are ramped past each other. A module-level `playbackClaimId` + `playbackOwner` pair guarantees only one engine makes sound at a time; an idle standby is freed after a timeout. |
+| `AudioEngine.ts` | Owns **two** hidden YouTube IFrame decks plus an optional `HTMLAudioElement`, and routes between them on `shouldUseNativeAudio()` — a live read of the audio-engine setting, so a change takes effect on the next track rather than the next launch. The standby deck holds the *next* track already cued, which is what makes transitions gapless; with a non-zero crossfade the two decks' volumes are ramped past each other. **Neither applies in native mode**, which has no deck to preload onto. `releaseIframePlayer()` frees the decks (and their subframe process) without disposing the engine; a module-level listener calls it on every engine except the current playback owner when the setting flips to native. `playbackClaimId` + `playbackOwner` guarantee only one engine makes sound at a time. |
 | `Queue.ts` | Pure queue data structure with three regions: played/current, a **manual queue** segment (`playNext` / `addToQueue`), and automatic upcoming tracks. Shuffle only touches the automatic region and remembers the original order so it can be restored. `move()` rejects cross-region moves. |
 | `PlayerController.ts` | One per tab. Orchestrates DataSource → AudioEngine → Queue, playback order (shuffle and repeat compose independently), crossfade/gapless settings, playback rate, stop-after-track, radio/autoplay refills, history, error surfacing, session export/restore, and Discord presence updates. |
 | `TabManager.ts` | Owns the `Map<tabId, PlayerController>`. Distinguishes the **focused** tab (what you're looking at) from the **playback owner** (what's making sound), and suspends/resumes engines on switch. |
@@ -194,7 +197,7 @@ Cache keys are versioned strings (`youtube-music:library:v5`, `youtube-music:tra
 | `playlistTransfer.ts` | Versioned JSON export/import of playlists. |
 | `recentPlaylists.ts` | Last-played timestamps per playlist for sidebar ordering. |
 | `playbackSettings.ts` | Volume/mute, playback rate, crossfade seconds, gapless flag — mirrored to durable settings. |
-| `appSession.ts` | Whole-app session snapshot in localStorage: tabs + per-tab player sessions. Restores `playing` as `paused` so launching the app never autoplays. Honours the "restore tabs and queues" setting. |
+| `appSession.ts` | Whole-app session snapshot in localStorage: tabs + per-tab player sessions. Restores `playing` as `paused` so launching the app never autoplays. Honours the "restore tabs and queues" setting. `saveAppSession` compares the serialized payload against the last one written and skips the (synchronous, disk-backed) `setItem` when nothing moved — it is called from three places and most calls are no-ops. |
 | `DiscordRPC.ts` | Sanitizes presence payloads (128-char text limit, HTTPS-only artwork from a trusted host allowlist) before invoking Rust. |
 | `LastFm.ts` | Tracks listened seconds, sends `nowPlaying` once per track and scrobbles at `min(240 s, duration/2)`; tracks shorter than 31 s never scrobble. |
 | `useMediaSession.ts` | Bridges player state to Windows SMTC (via `update_windows_media_session` + `windows-media-control` events) or, elsewhere, the WebView `navigator.mediaSession`. |
@@ -215,7 +218,7 @@ Detailed in [backend.md](./backend.md).
 | File | Responsibility |
 |---|---|
 | `main.rs` | Sets the Windows AppUserModelID, strips the WebView2 diagnostics env var, calls `run()` |
-| `lib.rs` (~3.8k lines) | Commands, cache, settings, logging, keyring/session + cookie jar, HTTP proxy, audio fetch, offline store, local files and tags, folder watcher, media server, tray, window event wiring |
+| `lib.rs` (~3.9k lines) | Commands, cache, settings, logging, keyring/session + cookie jar, HTTP proxy, audio fetch, offline store, local files and tags, folder watcher, media server, tray, window event wiring |
 | `discord_rpc.rs` | `DiscordIpcClient` lifecycle and activity building |
 | `lastfm.rs` | MD5-signed Last.fm API calls, session in keyring |
 | `windows_media.rs` | SMTC integration + taskbar thumbnail toolbar buttons |
@@ -235,9 +238,10 @@ main.tsx
   applyPaperPcMode()                 → data-paper-pc (reduced-motion / no blur theme)
   applyNativeWindowControls()        → window decorations on/off
   hydrateMainWindowGeometry() → restoreMainWindowGeometry()
-  Promise.all([ ~17 hydrate* calls: paperPc, theme, windowControls, miniPlayer, playerControls,
-                queuePanel, tray, audioQuality, lastFm, discord, sidebar, keyboardShortcuts,
-                toolbarItems, homeSections, playbackSettings, playHistory, sessionRestore ])
+  Promise.all([ ~18 hydrate* calls: paperPc, theme, windowControls, miniPlayer, playerControls,
+                queuePanel, tray, audioQuality, audioEngineMode, lastFm, discord, sidebar,
+                keyboardShortcuts, toolbarItems, homeSections, playbackSettings, playHistory,
+                sessionRestore ])
   DiscordRpcService.init()
   window error / unhandledrejection hooks
   createRoot().render(<StrictMode><ErrorBoundary><App/></ErrorBoundary></StrictMode>)
@@ -268,15 +272,19 @@ UI onClick
        dataSource.getTrack(videoId)                  cached, merged with the queued row
        ensureTrackLoaded(track)
           local / downloaded → local_audio_read | offline_audio_source → <audio>
-          remote             → audioEngine.loadTrack(videoId) → deck cueVideoById, wait for CUED
+          remote, iframe     → audioEngine.loadTrack(videoId) → deck cueVideoById, wait for CUED
+          remote, native     → getStreamData() → fetch_audio_source → <audio>
+                               (also releases the IFrame decks, freeing the subframe)
        audioEngine.play()                            claims global playback, waits for PLAYING
        setState({status:"playing"}) → recordPlay(track)
   → emit() → React re-render + Discord presence + Last.fm nowPlaying
 ```
 
-Ahead of the end of a track the engine cues the next one onto the **standby deck**. Track end
-(`onEnded`) then hands over: with `crossfadeSec` at 0 the swap is gapless; above 0 the two decks'
-volumes ramp past each other. Repeat-one replays instead; otherwise the next queue item; otherwise
+In `iframe` mode, ahead of the end of a track the engine cues the next one onto the **standby
+deck**. Track end (`onEnded`) then hands over: with `crossfadeSec` at 0 the swap is gapless; above 0
+the two decks' volumes ramp past each other. Native mode has no standby deck, so it neither
+preloads nor crossfades — `onEnded` on the `<audio>` element simply advances the queue.
+Repeat-one replays instead; otherwise the next queue item; otherwise
 queue-end recommendations (playlist mode); otherwise the radio queue if autoplay is on; otherwise
 pause. `refillAutomaticQueue()` tops the automatic region back up when fewer than 10 tracks remain
 and the queue isn't a fixed playlist.
@@ -289,16 +297,18 @@ letting a stale response overwrite state.
 
 | Track kind | Path |
 |---|---|
-| YouTube, streaming | No stream URL is fetched at all — the IFrame deck handles it from the video id. |
-| YouTube, downloaded | `offline_audio_source` serves the stored bytes from the local `127.0.0.1` media server, with Range support. No network. |
+| YouTube, streaming, `iframe` mode | No stream URL is fetched at all — the IFrame deck handles it from the video id. |
+| YouTube, streaming, `native` mode | `getStreamData` → `resolveStreamUrl` → `fetch_audio_source` downloads it, validates the MP4 `ftyp` box, and re-serves it from the local media server. |
+| YouTube, downloaded | `offline_audio_source` serves the stored bytes from the media server, with Range support. No network. |
 | YouTube, download | `getStreamData` → Innertube `getBasicInfo` → best adaptive `audio/mp4` at the configured quality → decipher → PO token → `offline_audio_save` fetches it in 4 MiB ranges, 6 at a time, emitting progress. |
-| YouTube, native fallback | `fetch_audio_source` downloads once, validates the MP4 `ftyp` box, and re-serves it from the media server. |
 | Local file | `local_audio_read` returns base64 bytes + a MIME type guessed from the extension; the frontend builds a `Blob` object URL. |
 
-`shouldUseNativeAudio()` returns `false` unconditionally — for *streaming* YouTube tracks the
-native path stays off. The comment in `AudioEngine.ts` records why: the backend download path
-returned 403s, so v1.2.65 reverted every platform to the IFrame player. The PO token work since
-then is what made the download path viable, and downloads use it.
+`shouldUseNativeAudio()` was hardcoded `false` from v1.2.65 — the backend download path answered
+403 for remote streams, so every platform was reverted to the IFrame player. **PO tokens are what
+fixed it**: the download feature has used this same resolve-and-fetch path successfully ever since,
+which is what made it safe to offer again as a setting. It stays opt-in because native resolves and
+downloads the whole track before the first sample plays (so a track starts slower) and because
+gapless and crossfade ride the standby IFrame deck, so neither applies to it.
 
 ### 4.4 Authentication
 
@@ -380,6 +390,7 @@ while `loadTrack`/`playTrackById` first *claim* the focused tab as the new owner
 | localStorage | WebView profile | Same settings (fast path) + session, play history, local playlists, playlist membership, offline manifest, recent playlists, recent searches, update snoozes |
 | Data cache | `<app_cache_dir>/data-cache-v1/entries/<fnv1a>.json` | Library, playlists, albums, artists, tracks, browse pages, lyrics, search results. LRU-evicted to a configurable budget (default 4 GiB) |
 | Offline audio | `<app_data_dir>/offline-audio-v1/<trackId>.bin` | Downloaded track bytes. The frontend keeps the metadata manifest in localStorage and reconciles it against `offline_audio_list`. Pruned oldest-first to a configurable ceiling (default 8 GiB) |
+| In-memory media bodies | `MediaServer.items`, Rust process | The audio currently playing and the one preloaded. Hard cap of 3 entries, coldest evicted — see [backend.md](./backend.md) §3 |
 | Secrets | OS keyring (`com.ytmusicdock.app`) — plus an AES-GCM file on macOS | YouTube cookie header, Last.fm session key |
 | Logs | `<app_log_dir>/current.log` | Truncated on every launch; older `*.log` files deleted |
 
@@ -455,9 +466,10 @@ Recorded so nobody re-derives them:
   (all `offline_audio_*`, `read_text_file`, `write_text_file`, `local_audio_*_tags`,
   `local_audio_watch`/`unwatch`, `refresh_youtube_music_cookie`, `open_current_log`) and nothing
   broke, which is the proof it is inert.
-- `AudioEngine.shouldUseNativeAudio()` is hardcoded `false`; the native streaming path exists but is
-  reachable only for local and downloaded files.
-- `App.tsx` is 2161 lines with ~30 `useEffect` blocks, some at zero indentation — still the
+- Gapless and crossfade silently do nothing in `native` audio-engine mode — they ride the standby
+  IFrame deck, which that mode has no equivalent of. The Settings copy says so, but nothing in the
+  code prevents the combination.
+- `App.tsx` is 2150 lines with ~30 `useEffect` blocks, some at zero indentation — still the
   highest-value refactor target in the repo.
 - `getStreamUrl` on the YouTube Music data source is required by the abstract class but never called
   by the controllers.

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -10,7 +10,7 @@ See [architecture.md](./architecture.md) for the system view.
 | File | Lines | Responsibility |
 |---|---|---|
 | `main.rs` | 24 | Windows AppUserModelID, WebView2 diagnostics workaround, calls `run()` |
-| `lib.rs` | ~3780 | Everything else: commands, cache, settings, logging, session storage + cookie jar, HTTP proxy, audio fetch, offline store, local files/tags/watcher, media server, tray, window events, builder wiring |
+| `lib.rs` | ~3870 | Everything else: commands, cache, settings, logging, session storage + cookie jar, HTTP proxy, audio fetch, offline store, local files/tags/watcher, media server, tray, window events, builder wiring |
 | `discord_rpc.rs` | 213 | Discord IPC client lifecycle and activity payloads |
 | `lastfm.rs` | 283 | Last.fm auth + scrobbling |
 | `windows_media.rs` | 630 | SMTC + taskbar thumbnail toolbar (Windows only) |
@@ -188,17 +188,27 @@ Why: the WebView can't set `Cookie`/`Origin` headers or bypass CORS, and Innertu
 | Command | Signature | Notes |
 |---|---|---|
 | `fetch_audio_bytes` | `(url, trackId) -> Vec<u8>` | Downloads with YouTube-ish headers (Range, Origin, Referer, Sec-Fetch-*), same signed-IP handling |
-| `fetch_audio_source` | `(url, trackId, mimeType) -> { url, mimeType, byteLength }` | Downloads, validates the MP4 `ftyp` box at offset 4, stores the bytes in the in-process media server, returns a `http://127.0.0.1:<port>/audio/<key>` URL |
+| `fetch_audio_source` | `(url, trackId, mimeType, cookie?) -> { url, mimeType, byteLength }` | Downloads, validates the MP4 `ftyp` box at offset 4, publishes the bytes under `stream-<trackId>`, returns a `http://127.0.0.1:<port>/audio/<key>` URL |
 | `fetch_youtube_music_audio` | `(videoId) -> { bodyBase64, mimeType }` | Direct InnerTube player API using web-remix / web / iOS / Android / TV contexts that return undeciphered URLs |
 
 **Media server**: a lazily started `TcpListener` on `127.0.0.1:0` with a thread per connection,
 backed by `HashMap<key, MediaItem>`, and `parse_media_range` implementing HTTP Range so the WebView
 can seek. It exists because signed googlevideo URLs 403 when replayed from the WebView, and base64
-blobs of a whole track are wasteful. Entries are in-memory for the process lifetime.
+blobs of a whole track are wasteful.
 
-**Note:** with `AudioEngine.shouldUseNativeAudio()` hardcoded to `false`, these three are on the
-fallback path only — ordinary streaming goes through the IFrame decks. Downloads use
-`offline_audio_save` below.
+Three things about it are load-bearing, and each fixed half of a leak that only became hot once
+`native` playback made `fetch_audio_source` the default streaming path:
+
+- **`store_media_item()` caps the map at `MEDIA_SERVER_MAX_ITEMS` (3)**, evicting the coldest by an `AtomicU64` sequence — a counter rather than a timestamp, because two inserts inside a millisecond still need an order. Two is the real working set (playing track plus preloaded); the third is slack for a fast skip. The map was previously insert-only, so every song ever played stayed resident.
+- **Keys are stable** — `stream-<trackId>` and `offline-<trackId>`. `fetch_audio_source` used to append a millisecond timestamp, so a replay stored a second copy of the same song *and* left the webview holding a response under a URL it would never request again.
+- **Responses carry `Cache-Control: no-store`.** Without it the webview keeps its own copy of every audio body — whole songs, in the renderer process, retained a second time by the one place that cannot be asked to give them back. The cost is that seeking backwards re-requests a range instead of reading the webview's copy, which over loopback against an in-memory `Vec<u8>` is a memcpy.
+
+Replacing a key mid-playback is safe: `handle_media_request` clones the `Arc` before it writes, so
+a request already in flight finishes against the bytes it started with.
+
+**Note:** which of these runs for ordinary streaming depends on the audio-engine setting. In
+`iframe` mode (the default) none of them do — the IFrame decks stream directly. Downloads always
+use `offline_audio_save` below.
 
 ### Audio — offline downloads
 
@@ -337,6 +347,8 @@ release workflow under `.github/workflows/`.
 | `signed_content_length_reads_clen` | `clen` parsing |
 | `sanitize_log_url_*` | secrets withheld by value, diagnostics kept, unparseable input |
 | `cookie_domain_matches_*` | exact, parent-domain, and rejection cases |
+| `media_items_stay_capped_and_evict_the_coldest_first` | `store_media_item` holds the cap and drops the oldest, not an arbitrary entry |
+| `restoring_the_same_track_replaces_rather_than_accumulates` | a stable key means a replay reuses its slot |
 
 The frontend's equivalent is `npm run check` (`scripts/run-checks.mjs` over `src/**/*.check.ts`).
 There is no component/DOM test harness on either side.

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -1,6 +1,6 @@
 # Backend — Rust / Tauri
 
-`src-tauri/` — Tauri 2, edition 2021, crate `just_another_music_client_lib`.
+`src-tauri/` — Tauri 2, edition 2021, crate `zuno`, lib target `zuno_lib`.
 See [architecture.md](./architecture.md) for the system view.
 
 ---
@@ -9,20 +9,22 @@ See [architecture.md](./architecture.md) for the system view.
 
 | File | Lines | Responsibility |
 |---|---|---|
-| `main.rs` | 25 | Windows AppUserModelID, WebView2 diagnostics workaround, calls `run()` |
-| `lib.rs` | ~2380 | Everything else: commands, cache, settings, logging, session storage, HTTP proxy, audio fetch, local media server, window events, builder wiring |
-| `discord_rpc.rs` | 190 | Discord IPC client lifecycle and activity payloads |
+| `main.rs` | 24 | Windows AppUserModelID, WebView2 diagnostics workaround, calls `run()` |
+| `lib.rs` | ~3780 | Everything else: commands, cache, settings, logging, session storage + cookie jar, HTTP proxy, audio fetch, offline store, local files/tags/watcher, media server, tray, window events, builder wiring |
+| `discord_rpc.rs` | 213 | Discord IPC client lifecycle and activity payloads |
 | `lastfm.rs` | 283 | Last.fm auth + scrobbling |
 | `windows_media.rs` | 630 | SMTC + taskbar thumbnail toolbar (Windows only) |
 | `macos_media.rs` | 189 | `MPNowPlayingInfoCenter` (macOS only) |
 
 ### Dependencies of note
 
-`tauri` (feature `macos-private-api`), `tauri-plugin-{autostart,opener,localhost,updater,process,dialog}`,
-`reqwest` (rustls-tls, gzip/brotli/deflate), `keyring` 3.6 with native backends, `discord-rich-presence`,
-`md5`, `base64`, `url`, `portpicker`.
-macOS adds `aes-gcm`, `objc2`, `objc2-foundation`, `block2`, `rand`. Windows adds the `windows` crate
-(Media, Media_Playback, Storage_Streams, Win32 Shell/Gdi/Com/UI).
+`tauri` (features `macos-private-api`, `tray-icon`, `image-png`),
+`tauri-plugin-{autostart,opener,localhost,updater,process,dialog}`,
+`reqwest` (rustls-tls, gzip/brotli/deflate, **stream**), `futures-util` (parallel range downloads),
+`keyring` 3.6 with native backends, `lofty` 0.24 (audio tag read/write), `notify` 8.2 (folder
+watching), `discord-rich-presence`, `md5`, `base64`, `url`, `portpicker`.
+macOS adds `aes-gcm`, `objc2`, `objc2-foundation`, `block2`, `rand`. Windows adds the `windows`
+crate (Media, Media_Playback, Storage_Streams, Win32 Shell/Gdi/Com/UI/Controls).
 
 ---
 
@@ -31,6 +33,7 @@ macOS adds `aes-gcm`, `objc2`, `objc2-foundation`, `block2`, `rand`. Windows add
 ```rust
 manage(CacheLock)            // Mutex<()> serializing all cache file ops
 manage(AppSettingsLock)      // Mutex<()> serializing settings file ops
+manage(YoutubeCookieJar)     // Mutex<CookieJarState> — the live session cookies
 manage(DiscordRpcManager)
 plugin(autostart, updater, process, dialog, opener)
 
@@ -41,10 +44,13 @@ plugin(autostart, updater, process, dialog, opener)
 
 #[cfg(windows)] manage(WindowsMediaSession)
 #[cfg(macos)]   manage(MacosMediaSession)
+manage(LocalAudioWatcher)
 
 #[cfg(linux)] force main window decorations = true   // mutated on the config before build
 
-setup      → initialize_app_log()
+setup      → migrate_legacy_app_data()   // before the log opens, so a first run after the
+           → initialize_app_log()        //   rename logs into the restored directory
+           → build_tray()                // always built; the setting only changes behaviour
 on_window_event → close / focus handling
 invoke_handler(...)
 ```
@@ -52,20 +58,29 @@ invoke_handler(...)
 Serving the frontend over `http://localhost` in release builds is deliberate: the YouTube IFrame
 player API will not initialize under the `tauri://` custom protocol origin.
 
+`migrate_legacy_app_data` copies app data from the pre-rename
+`com.justanothermusicclient.desktop` identifier into `com.zuno.desktop` on first run.
+
 ### Window events
 
 | Event | Behaviour |
 |---|---|
-| `CloseRequested` on `main` | `api.prevent_close()` then `app.exit(0)` — quits the whole app rather than orphaning the mini-player window |
-| `Focused(false)` on `main` | Spawns a thread, waits 100 ms, re-checks that neither main nor mini is focused, then emits `main-window-backgrounded` (debounce against focus flicker during window drags) |
+| `CloseRequested` on `main` | `api.prevent_close()` then `close_or_hide_main_window()` — hides to the tray if `minimize-to-tray` is set, otherwise `app.exit(0)`. The titlebar button routes through the same function via `quit_app`, so the two can't disagree |
+| `Focused(false)` on `main` | Spawns a thread, waits 100 ms, re-checks that neither main nor mini is focused, then emits `main-window-minimized` (if the window is minimized) or `main-window-backgrounded` — the debounce guards against focus flicker during window drags |
 | `Focused(true)` on `main` | Emits `window-focused` |
+
+### Tray
+
+`build_tray()` installs a `main-tray` icon with a two-item menu (**Show Zuno** / **Quit Zuno**).
+Left click restores the window; the menu is right-click only. **Quit Zuno** is the one path that
+always exits regardless of the minimize-to-tray setting.
 
 ---
 
 ## 3. Command reference
 
-Every command is invoked from TypeScript via `@tauri-apps/api/core`'s `invoke` and must also be
-listed in `src-tauri/capabilities/default.json`.
+Every command is invoked from TypeScript via `@tauri-apps/api/core`'s `invoke` and registered in
+`tauri::generate_handler!`.
 
 ### App settings — `<app_data_dir>/settings-v1.json`
 
@@ -77,7 +92,7 @@ listed in `src-tauri/capabilities/default.json`.
 | `app_settings_clear` | `()` | Used by "delete all app data" |
 
 Simple flat `HashMap<String, Value>`. Whole-file rewrite per key — fine at this scale, and the mutex
-prevents interleaved writes.
+prevents interleaved writes. Rust reads one key of its own out of this file: `minimize-to-tray`.
 
 ### Data cache — `<app_cache_dir>/data-cache-v1/`
 
@@ -107,14 +122,19 @@ Implementation details:
 directory. A local `eprintln!` macro shadows the std one so *all* Rust logging is routed through
 `sanitize_log_message` and appended to the same file.
 
+`sanitize_log_url` is the interesting half: it keeps the parameters that explain a googlevideo 403
+(`expire`, `itag`, `mime`, `clen`, `c`, `cver`) and replaces the rest — `sig`, `lsig`, `pot`, `n`,
+`ip` — with a `[9ch]`-style length marker, so a truncated signature is distinguishable from a
+missing one without leaking either. Unparseable input becomes `[redacted-url]`.
+
 ### YouTube session
 
 | Command | Signature | Notes |
 |---|---|---|
 | `sign_in_youtube_music` | `() -> String` | Opens the login window, polls for cookies, returns the Cookie header |
-| `load_youtube_music_cookie` | `() -> Option<String>` | |
+| `refresh_youtube_music_cookie` | `() -> Option<String>` | Silent re-mint in a hidden window, up to `YOUTUBE_SILENT_REFRESH_POLLS` (25) polls |
+| `load_youtube_music_cookie` | `() -> Option<String>` | Also seeds the in-memory cookie jar |
 | `delete_youtube_music_cookie` | `()` | Also clears the login window's browsing data if present |
-| `save_youtube_credentials` / `load_youtube_credentials` / `delete_youtube_credentials` | | Legacy OAuth-JSON slot, kept for migration/detection |
 
 **Sign-in flow** (`sign_in_youtube_music`): create window `youtube-music-login` at `about:blank` →
 `clear_all_browsing_data()` → navigate to the Google sign-in URL → poll once a second for up to 300
@@ -123,6 +143,25 @@ polls. Success requires *both* an auth cookie (`SAPISID` / `__Secure-1PAPISID` /
 persisted, and the window closes. If the user closes the window, the command errors with "cancelled".
 macOS reads cookies via `window.cookies()` filtered by `cookie_domain_matches` (unit-tested); other
 platforms use `cookies_for_url`. macOS also sets a Safari user agent so Google serves the desktop flow.
+
+**Cookie jar.** Google rotates session cookies continuously, and a session that only ever stores what
+sign-in returned goes stale overnight. `proxy_http_request` feeds every `Set-Cookie` from a YouTube
+host through `apply_set_cookie`, which merges it into `YoutubeCookieJar` in original order:
+
+- a rotated value replaces the stale one and reports a change,
+- the same value again reports *no* change, so it triggers no keyring write,
+- an expiry/`max-age=0` tombstone drops the cookie.
+
+Credential rotations (`__Secure-*PSIDTS`, `SAPISID`, …) are persisted immediately.
+`is_slow_persist_cookie` marks only the noisy `SIDCC` family as allowed to wait for the
+`YOUTUBE_COOKIE_PERSIST_INTERVAL` (5 min) — getting that list backwards is what once made a session
+look lost after a `PSIDTS` rotated at 23:58 and never got written. `is_youtube_cookie_host` gates
+the whole thing: a suffix match alone would hand the session to `notyoutube.com`.
+
+`cookie_account_identity()` reduces a header to its `SAPISID` (falling back to
+`__Secure-1PAPISID` / `__Secure-3PAPISID`), so a re-signed-in session is recognised as the same
+account and keeps its cache, while a genuinely different account drops it. An empty value returns
+`None` rather than `""`, so two unknowns don't compare equal.
 
 **Storage** (service name `com.ytmusicdock.app`, kept from before the rename):
 
@@ -139,29 +178,68 @@ Every youtubei.js request goes through here (`src/datasource/youtube/tauriFetch.
 Why: the WebView can't set `Cookie`/`Origin` headers or bypass CORS, and Innertube needs both.
 
 - Fixed Chrome 135 user agent.
+- Merges response `Set-Cookie` headers into the cookie jar (see above).
 - `signed_googlevideo_local_address()` — signed googlevideo URLs embed an `ip=` parameter; the client binds `local_address` to the matching IP family (`0.0.0.0` or `::`) so the signature stays valid on dual-stack machines.
 - Cookie and Authorization headers are redacted in logs.
 - `/browse` responses under 400 get their renderer types counted into the debug log — a diagnostic for when YouTube changes response shapes.
 
-### Audio
+### Audio — streaming and fallback
 
 | Command | Signature | Notes |
 |---|---|---|
 | `fetch_audio_bytes` | `(url, trackId) -> Vec<u8>` | Downloads with YouTube-ish headers (Range, Origin, Referer, Sec-Fetch-*), same signed-IP handling |
 | `fetch_audio_source` | `(url, trackId, mimeType) -> { url, mimeType, byteLength }` | Downloads, validates the MP4 `ftyp` box at offset 4, stores the bytes in the in-process media server, returns a `http://127.0.0.1:<port>/audio/<key>` URL |
-| `fetch_youtube_music_audio` | `(videoId) -> { bodyBase64, mimeType }` | Direct InnerTube player API using iOS/TV contexts that return undeciphered URLs |
-| `local_audio_scan` | `(paths: Vec<String>) -> Vec<LocalAudioFile>` | Recursive directory walk; extensions mp3, m4a, mp4, aac, flac, wav, ogg, oga, opus, webm. Sorted case-insensitively and deduped. Album name is inferred from the parent folder |
-| `local_audio_read` | `(path) -> { bodyBase64, mimeType }` | Re-validates the path is a file with an allowed extension before reading |
+| `fetch_youtube_music_audio` | `(videoId) -> { bodyBase64, mimeType }` | Direct InnerTube player API using web-remix / web / iOS / Android / TV contexts that return undeciphered URLs |
 
 **Media server**: a lazily started `TcpListener` on `127.0.0.1:0` with a thread per connection,
-backed by `HashMap<key, MediaItem>`. It exists so the WebView can stream MP4 audio from a plain
-`http://` origin — signed googlevideo URLs 403 when replayed from the WebView, and base64 blobs of
-a whole track are wasteful. Entries are keyed `"<trackId>-<epoch_ms>"` and never evicted (in-memory,
-process lifetime).
+backed by `HashMap<key, MediaItem>`, and `parse_media_range` implementing HTTP Range so the WebView
+can seek. It exists because signed googlevideo URLs 403 when replayed from the WebView, and base64
+blobs of a whole track are wasteful. Entries are in-memory for the process lifetime.
 
-**Note:** with `AudioEngine.shouldUseNativeAudio()` hardcoded to `false`, `fetch_audio_bytes`,
-`fetch_audio_source`, and `fetch_youtube_music_audio` are currently only reachable through the
-local-file path or manual re-enablement.
+**Note:** with `AudioEngine.shouldUseNativeAudio()` hardcoded to `false`, these three are on the
+fallback path only — ordinary streaming goes through the IFrame decks. Downloads use
+`offline_audio_save` below.
+
+### Audio — offline downloads
+
+| Command | Signature | Notes |
+|---|---|---|
+| `offline_audio_save` | `(url, trackId, cookie?) -> u64` | Downloads the signed URL into `<app_data_dir>/offline-audio-v1/<trackId>.bin`, returns byte length |
+| `offline_audio_source` | `(trackId, mimeType) -> { url, mimeType, byteLength }` | Loads the stored bytes into the media server under key `offline-<trackId>` and returns its URL |
+| `offline_audio_has` | `(trackId) -> bool` | |
+| `offline_audio_remove` | `(trackId)` | |
+| `offline_audio_list` | `() -> Vec<{ trackId, byteLength }>` | The source of truth the frontend manifest reconciles against |
+| `offline_audio_stats` | `() -> { entryCount, usedBytes }` | |
+| `offline_audio_prune` | `(maxBytes) -> OfflineStats` | Deletes oldest-first until under the ceiling |
+
+- **Ranged and parallel.** `OFFLINE_CHUNK_BYTES` is 4 MiB and `OFFLINE_CHUNK_CONCURRENCY` is 6.
+  googlevideo throttles a single sequential stream hard, which is why downloading a track used to
+  take far longer than streaming the same track takes to buffer; several ranges in flight side-step
+  it. `signed_content_length()` reads `clen` from the URL to plan the ranges, and
+  `audio_url_with_range()` appends `range=start-end` without re-encoding the query (re-encoding `==`
+  breaks the signature).
+- **Progress.** `emit_offline_progress` emits `offline-download-progress`
+  `{ trackId, receivedBytes, totalBytes, percent }`.
+- **Path safety.** `offline_entry_path` rejects ids that are empty, contain `..`, or contain
+  `/ \ : \0` — track ids come from YouTube and are filename-safe, but a hostile one must not escape
+  the directory.
+
+### Local files
+
+| Command | Signature | Notes |
+|---|---|---|
+| `local_audio_scan` | `(paths: Vec<String>) -> Vec<LocalAudioFile>` | Recursive directory walk; extensions mp3, m4a, mp4, aac, flac, wav, ogg, oga, opus, webm. Sorted case-insensitively and deduped. Album name is inferred from the parent folder |
+| `local_audio_read` | `(path) -> { bodyBase64, mimeType }` | Re-validates the path is a file with an allowed extension before reading |
+| `local_audio_read_tags` | `(path) -> LocalAudioTags` | `lofty` |
+| `local_audio_write_tags` | `(path, tags)` | `lofty` |
+| `local_audio_watch` | `(paths: Vec<String>)` | Replaces the active `notify` watcher wholesale; emits `local-audio-changed` at most once a second |
+| `local_audio_unwatch` | `()` | Drops the watcher, which unregisters every path |
+| `read_text_file` | `(path) -> String` | Playlist import. Capped at 16 MiB — the picker allows any file, and reading a multi-gigabyte one into a `String` to discover it isn't a playlist would take the app down |
+| `write_text_file` | `(path, contents)` | Playlist export; creates the parent directory |
+
+The watcher is deliberately coarse: one debounced "something changed" event, no diff. A precise
+change feed would have to model renames, temp files and write-then-replace editors, all of which
+produce the same user-visible outcome — a rescan.
 
 ### Integrations
 
@@ -173,9 +251,9 @@ local-file path or manual re-enablement.
 | `lastfm_complete_auth` | | `auth.getSession` → stores the session key in the keyring |
 | `lastfm_get_session` / `lastfm_disconnect` | | |
 | `lastfm_update_now_playing` / `lastfm_scrobble` | | MD5 `api_sig` over sorted params + shared secret |
-| `update_windows_media_session` | `windows_media.rs` | Windows only |
+| `update_windows_media_session` | `windows_media.rs` | Windows only (`#[cfg]` inside `generate_handler!`) |
 | `update_macos_media_session` | `macos_media.rs` | macOS only |
-| `quit_app` | `lib.rs` | `app.exit(0)` |
+| `quit_app` | `lib.rs` | Routes to `close_or_hide_main_window` |
 | `greet` | `lib.rs` | Tauri scaffolding leftover; unused |
 
 **Windows media** (`windows_media.rs`): a `MediaPlayer` + `SystemMediaTransportControls` pair driving
@@ -198,19 +276,28 @@ authorizes writes. Session key lives in the keyring under `lastfm-session-v1`.
 
 `src-tauri/capabilities/default.json` scopes both windows (`main`, `mini-player`):
 
-- Core window permissions: drag, minimize/maximize/unmaximize, fullscreen, decorations, show/hide/focus, position/size get+set, cursor position and icon, ignore-cursor-events (the mini player's click-through behaviour).
+- Core window permissions: drag, minimize/maximize/unmaximize, fullscreen, decorations, show/hide/focus/destroy, position/size get+set, current monitor, cursor position and icon, ignore-cursor-events (the mini player's click-through behaviour), and webview-window creation.
 - Plugin permissions: `autostart:{enable,disable,is-enabled}`, `opener:default`, `updater:default`, `process:allow-restart`, `dialog:{allow-open,allow-message}`.
-- An explicit `command.allow` list naming every custom command.
 - `remote.urls` permits `https://**` and localhost/127.0.0.1.
+
+**The `command.allow` and `allowlist.shell` blocks in that file are Tauri 1 syntax and gate nothing
+in Tauri 2** — capabilities scope *core and plugin* permissions; your own `#[tauri::command]`
+functions are callable from the app's own windows once they're in `generate_handler!`. The proof is
+that the list is missing every command added since it was written (all `offline_audio_*`,
+`read_text_file`, `write_text_file`, `local_audio_*_tags`, `local_audio_watch`/`unwatch`,
+`refresh_youtube_music_cookie`, `open_current_log`) and all of them work. Either delete the two
+blocks or stop treating them as a checklist; do not add to them expecting an effect.
 
 `app.security.csp` is `null` — no CSP. Required because the YouTube IFrame API script is loaded from
 `youtube.com` at runtime. If native playback ever replaces the IFrame path, this should be tightened.
 
 Defense in depth that *is* in place:
 
-- Two-stage log redaction (TS `sanitizeForLog` → Rust `sanitize_log_message`).
+- Two-stage log redaction (TS `sanitizeForLog` → Rust `sanitize_log_message` / `sanitize_log_url`).
+- Cookie jar writes are gated on `is_youtube_cookie_host`, an exact-or-parent-domain check.
 - Discord artwork restricted to `i.ytimg.com` / `lh3.googleusercontent.com` / `yt3.ggpht.com`, presence links to YouTube hosts, HTTPS only.
-- `local_audio_read` re-validates path and extension rather than trusting the frontend.
+- `local_audio_read` / `local_audio_write_tags` re-validate path and extension rather than trusting the frontend; `read_text_file` is size-capped.
+- `offline_entry_path` rejects traversal in track ids.
 - Secrets never touch localStorage — keyring or an encrypted file only.
 
 ---
@@ -230,9 +317,26 @@ Defense in depth that *is* in place:
 fallback if the Releases redirect is unavailable. macOS skips the plugin entirely
 (`internal/updateChecker.ts` uses the GitHub Releases API and only links to the download page).
 
+Linux packaging lives outside `src-tauri/`: `packaging/aur/` (PKGBUILD + `.SRCINFO`),
+`packaging/flatpak/` (manifest, desktop entry, metainfo), and `manifests/` for winget — each with a
+release workflow under `.github/workflows/`.
+
 ---
 
 ## 6. Tests
 
-`lib.rs` carries one `#[cfg(test)]` module covering `cookie_domain_matches` — exact, parent-domain,
-and rejection cases. That's the whole automated test suite; there is no frontend test harness.
+`cargo test` runs the `#[cfg(test)]` module at the bottom of `lib.rs`:
+
+| Test | Covers |
+|---|---|
+| `set_cookie_merges_rotations_into_the_stored_session` | `apply_set_cookie` — replace, add, no-op, tombstone, order preservation |
+| `only_the_noisy_cookies_may_be_persisted_late` | `is_slow_persist_cookie` — `SIDCC` may wait, credentials may not |
+| `account_identity_survives_a_renewal_and_changes_with_the_account` | `cookie_account_identity` fallbacks and the empty-value `None` |
+| `only_youtube_hosts_touch_the_cookie_jar` | `is_youtube_cookie_host` rejects `notyoutube.com` and googlevideo |
+| `audio_url_with_range_appends_without_disturbing_the_signature` | query present/absent, percent-encoding preserved |
+| `signed_content_length_reads_clen` | `clen` parsing |
+| `sanitize_log_url_*` | secrets withheld by value, diagnostics kept, unparseable input |
+| `cookie_domain_matches_*` | exact, parent-domain, and rejection cases |
+
+The frontend's equivalent is `npm run check` (`scripts/run-checks.mjs` over `src/**/*.check.ts`).
+There is no component/DOM test harness on either side.

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -1,8 +1,8 @@
 # Frontend — components, pages, modules
 
-React 19 + TypeScript, CSS Modules, `@tabler/icons-react`. No router, no CSS framework, no state
-library. See [architecture.md](./architecture.md) for the system view and [backend.md](./backend.md)
-for the IPC surface.
+React 19 + TypeScript, Tailwind v4, `motion` for animation, Solar icons. No router, no state
+library, no CSS Modules. See [architecture.md](./architecture.md) for the system view and
+[backend.md](./backend.md) for the IPC surface.
 
 ---
 
@@ -10,15 +10,18 @@ for the IPC surface.
 
 ### `src/main.tsx` — main window
 
-Runs before React mounts:
+Runs before React mounts, in this order:
 
-1. `applyPlatformAttributes()` — sets `data-platform-linux` on `<html>`.
-2. `applyPaperPcMode()` / `applyNativeWindowControls()` — synchronous theme + decoration flags from localStorage.
-3. `hydrateMainWindowGeometry()` → `restoreMainWindowGeometry()`.
-4. `Promise.all` of the seven `hydrate*` functions (paperPc, windowControls, miniPlayer, playerControls, lastFm, keyboardShortcuts, playbackSettings) — these reconcile localStorage against Rust-owned durable settings.
-5. `DiscordRpcService.init()`.
-6. `window.error` + `window.unhandledrejection` → `logInternalError`.
-7. `createRoot().render(<React.StrictMode><App/></React.StrictMode>)`.
+1. `hydrateArtworkCache()` — a resolution restored after first paint is one that already flashed the fallback icon.
+2. `applyPlatformAttributes()` — sets `data-platform-linux` on `<html>`.
+3. `applyTheme()` + `watchSystemTheme()` — sets `data-theme`; `system` keeps following the OS rather than resolving once.
+4. `applyPaperPcMode()` / `applyNativeWindowControls()` — synchronous theme + decoration flags from localStorage.
+5. `hydrateMainWindowGeometry()` → `restoreMainWindowGeometry()`.
+6. `Promise.all` of ~17 `hydrate*` functions (paperPc, theme, windowControls, miniPlayer, playerControls, queuePanel, tray, audioQuality, lastFm, discord, sidebar, keyboardShortcuts, toolbarItems, homeSections, playbackSettings, playHistory, sessionRestore) — these reconcile localStorage against Rust-owned durable settings.
+7. `DiscordRpcService.init()`.
+8. `window.error` + `window.unhandledrejection` → `logInternalError`.
+9. `createRoot().render(<StrictMode><ErrorBoundary label="Zuno"><App/></ErrorBoundary></StrictMode>)` — the outermost boundary exists because a desktop shell has no address bar to reload a blank window from.
+10. `syncLocalAudioWatcher()` and `listen("local-audio-changed")` → `notifyLocalPlaylistsChanged()`.
 
 ### `src/mini.tsx` — mini-player window
 
@@ -29,29 +32,38 @@ controllers — all state arrives over Tauri events from the main window.
 
 ## 2. `App.tsx` — the root
 
-1717 lines, the only component with meaningful state. It owns:
+2161 lines, the only component with meaningful state. It owns:
 
 | Concern | State / refs |
 |---|---|
 | Tabs | `tabs: Tab[]`, `activeTabId`, `nextTabId` — restored from `loadAppSession()` |
 | Navigation | Per-tab `navigationHistory: { back: TabViewState[], forward: TabViewState[] }` |
-| Layout | `sidebarWidth`, right-panel width, queue-panel open state |
+| Layout | `sidebarWidth`, queue-panel open/collapsed state |
 | Onboarding | `onboardingStep`, keychain notice, completion toast |
-| Updates | `availableUpdate`, snooze handling |
+| Updates | `availableUpdate`, snooze handling, release note dialog |
 | Loading screen | `loadingScreenState`, min 1000 ms / max 4000 ms, 80 ms fade |
 | Mini player | positioning, focus-driven show/hide, suppression windows during drags |
 | Recovery | sleep detection (15 s timer, 60 s drift threshold) → reload; connection recovery on window focus |
 
+Every page below it is `lazy`-loaded behind `Suspense`. Only Home is reachable at startup; the
+chunks come off local disk in a Tauri app, so the win is startup parse/compile time rather than
+transfer size. Each page is a named export, hence the `.then(m => ({ default: m.X }))` shim.
+
 ### The tab model (`ui/types/tab.ts`)
 
 ```ts
-type TabView = "home" | "album" | "artist" | "playlist" | "search" | "settings";
+type TabView =
+  | "home" | "album" | "artist" | "playlist" | "related"
+  | "search" | "history" | "browse" | "library" | "settings";
+type NavigableTabView = Exclude<TabView, "settings">;
 
 interface Tab {
   id: string;
   view: TabView;
   title?: string;
+  browseTab?: string;                 // which Browse surface; only meaningful when view is "browse"
   album?: Album; artist?: Artist; playlist?: Playlist;
+  relatedTrack?: Track;               // the track a "related" view is about
   searchQuery?: string; searchResults?: Track[]; mixedSearchResults?: SearchResults;
   searchLoading?: boolean;
   isQueueOpen?: boolean;
@@ -66,82 +78,106 @@ history out of the persisted session.
 
 ### Global keyboard handling
 
-Shortcuts come from `ui/settings/keyboardShortcuts.ts` (user-remappable, persisted). `App.tsx`
-matches them with `eventMatchesShortcut` for: play/pause, mute, previous/next, new tab, close tab,
-search, navigate back/forward, and jump-to-tab 1–9. Mouse buttons 3/4 map to back/forward.
-`ui/pages/pageSearchKeyboard.ts` decides when a bare printable keypress should start in-page search —
-it refuses when focus is in a text field or when the key matches any bound shortcut.
+Shortcuts come from `ui/settings/keyboardShortcuts.ts` (user-remappable, persisted) — 19 actions:
+`playPause`, `mute`, `previousTrack`, `nextTrack`, `closeTab`, `newTab`, `search`,
+`navigateBack`/`Forward`, and `tab1`–`tab9`. `App.tsx` matches them with `eventMatchesShortcut`;
+mouse buttons 3/4 map to back/forward. `ui/pages/pageSearchKeyboard.ts` decides when a bare
+printable keypress should start in-page search — it refuses when focus is in a text field or when
+the key matches any bound shortcut.
 
 ### Render tree
 
 ```
-<ArtistNavigationProvider>          artist-link click → navigate current tab
- <TrackContextMenuProvider>         right-click track menu, like/queue/playlist actions
-  <PlaylistContextMenuProvider>     right-click playlist/album menu
-   <TitleBar>                       drag region, MusicTabs, window controls
-   <Layout sidebar + rightPanel>    Sidebar, SearchBar, StarField, custom scrollbar
-     └ page: HomePage | AlbumView | ArtistView | PlaylistView | SearchResultsPage | SettingsPage
-     └ rightPanel: <QueuePanel>
-     └ overlay: <LyricsView>
-   <PlayerBar>                      TrackInfo, PlaybackControls, SeekBar, VolumeControl, LyricsButton
-   <SearchOverlay>                  Ctrl/⌘+K
-   <AppLoadingScreen> <KeychainNotice> <Onboarding*> <UpdateToast>
+<MotionConfig reducedMotion>        driven by Paper-PC mode; stops beUI's JS motion
+ <ArtistNavigationProvider>         artist-link click → navigate current tab
+  <TrackContextMenuProvider>        right-click track menu, like/queue/playlist actions
+   <PlaylistContextMenuProvider>    right-click playlist/album menu
+    <TitleBar>                      drag region, MusicTabs, toolbar items, window controls
+    <Layout sidebar + rightPanel>   Sidebar, SearchBar, StarField, custom scrollbar
+      └ page (lazy): HomePage | AlbumView | ArtistView | PlaylistView | RelatedPage
+                   | SearchResultsPage | LibraryPage | BrowsePage | HistoryPage | SettingsPage
+      └ rightPanel: <QueuePanel>    full or collapsed to a 62px artwork rail
+      └ overlay:    <LyricsView>
+    <PlayerBar>                     TrackInfo, PlaybackControls, SeekBar, VolumeControl,
+                                    DownloadButton, PlaybackOptions, LyricsButton
+    <VolumeSyncBridge>              leaf subscriber; keeps volume drags off the root
+    <SelectionBar>                  multi-select actions, docked above the player bar
+    <SearchOverlay>                 Ctrl/⌘+K
+    <AuthOverlay> <AppLoadingScreen> <KeychainNotice> <Onboarding*>
+    <UpdateToast> <ReleaseNoteDialog>
 ```
 
 ---
 
 ## 3. Components (`src/ui/components/`)
 
-Every component has a co-located `*.module.css`.
+Tailwind classes inline; there are no `*.module.css` files.
 
 ### Chrome and layout
 
 | Component | Purpose |
 |---|---|
-| `TitleBar.tsx` | Custom frameless title bar: drag region, home button (collapses to icon-only under 120 px sidebar), embedded `MusicTabs`, and minimize/maximize/close. Honours the "Windows-style controls" and "native controls" settings; hidden entirely when native decorations are on. |
-| `MusicTabs.tsx` | Tab strip with pointer-based drag reorder, close buttons, a volume icon marking the tab currently producing sound, and a 32-char title ellipsis. |
-| `Layout.tsx` | Three-column shell: resizable sidebar, page content, optional right panel. Implements a custom transient scrollbar (browser scrollbars are hidden globally in `global.css`) with hover/drag persistence and 760 ms auto-hide. Renders `StarField` unless Paper-PC mode is on. |
-| `Sidebar.tsx` | Library navigation: liked songs, playlists, albums, local playlists. Drag-and-drop ordering persisted per list (`ytc-sidebar-playlist-order`, `ytc-sidebar-album-order`) with a one-time migration pinning Liked Songs first. Sorts by recent-play timestamps. Right-click opens the playlist context menu. |
+| `TitleBar.tsx` | Custom frameless title bar: drag region, home button, embedded `MusicTabs`, optional toolbar items (downloads, notifications, account), and minimize/maximize/close. Honours the "Windows-style controls" and "native controls" settings; hidden entirely when native decorations are on. |
+| `MusicTabs.tsx` | Tab strip with pointer-based drag reorder, close buttons, a volume icon marking the tab currently producing sound, and a title ellipsis. |
+| `Layout.tsx` | Three-column shell: resizable sidebar, page content, optional right panel. Implements a custom transient scrollbar (browser scrollbars are hidden globally in `global.css`) with hover/drag persistence and auto-hide. Renders `StarField` unless Paper-PC mode is on, and subscribes to `ambientArtworkStore` for the accent wash behind the chrome. |
+| `Sidebar.tsx` | Library rail: liked songs, playlists, albums, local playlists. Three width modes (`collapsed` 62px / `expanded` 240px / `hover`). Ordering, filtering and drag-reorder logic lives in `sidebarLibrary.ts` (with a `.check.ts`) precisely because dropping a row while the list is filtered or alphabetised would write an order derived from a list the user wasn't looking at. |
 | `SearchBar.tsx` | Inline search entry in the layout header; opens the overlay. |
 | `StarField.tsx` | Decorative animated background; skipped in Paper-PC mode. |
+| `FloatingPanel.tsx` | Shared anchored-popover shell for the title-bar panels: side selection, 10px gap, 12px viewport margin. |
+| `ErrorBoundary.tsx` | Wraps the app root and each lazy page. React unmounts the whole tree on an unhandled render error — in a desktop shell that's a permanently blank window. |
 
 ### Content and interaction
 
 | Component | Purpose |
 |---|---|
-| `SearchOverlay.tsx` | ⌘/Ctrl+K palette. Fuzzy-scores your playlists/albums locally (`searchMatchScore`: exact 4 → prefix 3 → contains 2 → reverse-contains 1, with NFKD-normalized fallbacks), fetches remote suggestions, keeps 5 recent searches. Shift-Enter opens results in a new tab. |
-| `TrackContextMenu.tsx` | React context provider + menu: like/unlike, play next, add to queue, add to playlist (with submenu and pending state), remove from playlist, copy link, search artist. Handles viewport-edge flipping via `useLayoutEffect`. |
-| `PlaylistContextMenu.tsx` | Same pattern for playlists/albums: play, save/unsave, local-playlist management, remove. |
+| `SearchOverlay.tsx` | ⌘/Ctrl+K palette. Fuzzy-scores your playlists/albums locally (`searchMatchScore`: exact 4 → prefix 3 → contains 2 → reverse-contains 1, with NFKD-normalized fallbacks), fetches remote suggestions, keeps recent searches, and recognises a pasted YouTube link (`looksLikeYouTubeLink`) to resolve rather than search. Shift-Enter opens results in a new tab. |
+| `TrackRow.tsx` | The one row used by every track list. `memo`'d with `propsEqual`, which ignores handler identity — comparing inline arrows with `Object.is` meant the memo never returned true and did nothing at all, rebuilding 500 rows to repaint two. Handlers are invoked through a ref refreshed each render, which is what makes that safe. |
+| `TrackContextMenu.tsx` | React context provider + menu: like/dislike, play next, add to queue, add to playlist (with submenu and pending state), remove from playlist, download/remove download, edit tags (local files), copy link, search artist, go to related. Viewport-edge flipping via `useLayoutEffect`. |
+| `PlaylistContextMenu.tsx` | Same pattern for playlists/albums: play, save/unsave, rename/describe/delete, local-playlist management, import/export, download all, remove. |
+| `SelectionBar.tsx` | Bulk actions for a multi-selection, floating above the player bar so it doesn't push the list around as it appears. |
+| `MediaHeader.tsx` | Shared album/playlist/artist header. Its "24 songs · 1 hr 32 min" line drops the duration unless every counted track reported one *and* the list is fully loaded — YouTube omits `durationSec` on most playlist entries, and summing what happens to be present read "98 songs · 3 min". |
+| `BrowseShelves.tsx` | Horizontal scrollable shelves for browse/related surfaces, clipped at the edge to hint at more. |
+| `HomeDestinations.tsx` | Library / History / Downloads / Browse entry points on the home page, with live counts — they moved off the collapsed rail because unlabelled glyphs there competed with playlist artwork for attention. |
+| `AccountSwitcher.tsx` | Channel/brand-account picker plus the shared `AccountAvatar` (a new URL gets a fresh attempt, so one broken image doesn't poison the slot). |
+| `GoogleSignInButton.tsx` | The single sign-in button used everywhere. Previously three different-looking buttons for the same consequential action. |
+| `AuthOverlay.tsx` | Progress for sign-in and account-switch, driven by `LibraryState.authProgress`. The stages are listed per flow rather than filtered from one array — switching channel has no browser step, and rendering it as "skipped" would claim something that never happened. |
+| `NotificationsPanel.tsx` | Artist release feed with an unseen badge, refreshed on a slow interval — new releases arrive on the order of days. |
+| `DownloadsPanel.tsx` | Recent downloads (4) with progress and byte totals; the full list is the `downloads` browse surface. |
+| `TagEditor.tsx` | Local-file tag editing via `local_audio_read_tags` / `local_audio_write_tags`. |
 | `ArtistLinks.tsx` | Renders `Track.artists[]` as individually clickable links through `ArtistNavigationProvider`; falls back to the plain artist string. |
-| `TrackArtwork.tsx` | Artwork with loading/fallback states and consistent sizing. |
-| `AlbumCard.tsx` | Grid card for albums/playlists. |
-| `DiceCard.tsx` / `MagicDice.tsx` | The "surprise me" shuffle entry point on the home page. |
-| `Onboarding.tsx` | `OnboardingWelcome`, stepped `Onboarding`, `OnboardingCompleteToast`, and `KeychainNotice` (macOS keychain-prompt explainer). |
+| `TrackArtwork.tsx` | Artwork with loading/fallback states, backed by `internal/artworkCache.ts` so remounts don't rewalk the candidate URLs. |
+| `AlbumCard.tsx` / `PickCard.tsx` | Grid card and carousel card (the latter distinguishes a tap from a carousel drag with a 5px slop). |
+| `DiceCard.tsx` | The "surprise me" shuffle entry point on the home page. |
+| `ExternalLinkButton.tsx` | Open-or-copy with inline outcome feedback. |
+| `Onboarding.tsx` | `OnboardingWelcome`, stepped `Onboarding` (`onboardingSteps.ts`), `OnboardingCompleteToast`, and `KeychainNotice` (macOS keychain-prompt explainer). |
 | `AppLoadingScreen.tsx` | Startup splash with a leaving/fade state. |
-| `UpdateToast.tsx` | Update available → download progress → restart, or "open release page" on macOS. |
+| `UpdateToast.tsx` / `ReleaseNoteDialog.tsx` | Update available → download progress → restart (or "open release page" on macOS); and the one-time post-update note. |
 
 ### Player (`components/player/`)
 
 | Component | Purpose |
 |---|---|
-| `PlayerBar.tsx` | Bottom bar composing the pieces below; also surfaces connection-restored recovery. |
+| `PlayerBar.tsx` | Bottom bar composing the pieces below; also surfaces connection-restored recovery. Compact and expanded layouts (`playerControls.ts`). |
 | `TrackInfo.tsx` | Artwork + title + `ArtistLinks`, click-through to album/artist. |
-| `PlaybackControls.tsx` | Previous / play-pause / next, plus shuffle-repeat cycling (`in-order → shuffle → repeat-one` in playlist mode, `shuffle ⇄ repeat-one` otherwise). |
+| `PlaybackControls.tsx` | Previous / play-pause / next, shuffle and repeat as independent toggles. |
 | `SeekBar.tsx` | Position scrubber; writes `isSeeking` to `playerUIStore` so position polling doesn't fight the drag. |
 | `VolumeControl.tsx` | Slider + mute; writes `isDraggingVolume` to the UI store. |
+| `VolumeSyncBridge.tsx` | Mirrors volume/mute to the mini window. A leaf component rather than an effect in `App` on purpose: volume commits on every pointer move, and subscribing at the root re-rendered the whole tree per drag. |
+| `DownloadButton.tsx` | Download / cancel / remove for the **now-playing** track specifically — an indicator that lit up for any queued download reported on a song the listener hadn't thought about in ten minutes. |
+| `PlaybackOptions.tsx` | Playback speed (0.75–2×) and a sleep timer (15–90 min, plus "end of track"). |
 | `LyricsButton.tsx` | Toggles the lyrics overlay. |
-| `QueuePanel.tsx` | Right-panel queue with drag reorder, remove, and jump-to-index. Reordering is restricted to within a queue region (manual↔manual, automatic↔automatic) — `Queue.move()` rejects cross-region moves. |
+| `QueuePanel.tsx` | Right-panel queue with drag reorder, remove, jump-to-index, and stop-after-track. Collapses to a 62px artwork rail. Reordering is restricted to within a queue region (manual↔manual, automatic↔automatic) — `Queue.move()` rejects cross-region moves (`Queue.check.ts`). |
 | `ExpandedPlayerBar.tsx` | **Not rendered** — its JSX in `App.tsx` is commented out. |
 
 ### Mini player (`components/mini-player/MiniPlayer.tsx`)
 
-A 160×80 transparent always-on-top pill in its own window.
+A transparent always-on-top pill in its own window (~1.1k lines).
 
-- Appears on `main-window-backgrounded`, hides on `window-focused`.
-- Expands on hover into a two-pill layout (top 36 px + bottom 40 px, 2 px gap) with transport controls.
-- Right-mouse or empty-area drag moves the window; the position is debounced (350 ms) into settings.
+- Appears on `main-window-backgrounded` / `main-window-minimized`, hides on `window-focused`.
+- Expands on hover into a two-pill layout with transport controls.
+- Right-mouse or empty-area drag moves the window; the position is debounced into settings and echoed as `mini-player:position-changed`.
 - Hover behaviour over the progress area is configurable: `seek` or `volume` (`mini-player-hover-action`).
-- Communicates purely over Tauri events — player status, time, and volume snapshots in; control commands out.
+- Communicates purely over Tauri events. It asks for `mini-player:request-sync` only *after* its `player-state-sync` listener is live, so the reply can't arrive before anything is listening.
 
 ---
 
@@ -149,13 +185,18 @@ A 160×80 transparent always-on-top pill in its own window.
 
 | Page | Notes |
 |---|---|
-| `HomePage.tsx` | Recently played + generated suggestions. Suggestions are memoized per tab in module-level `Map`s (`suggestionCache`, `suggestionLoads`) so switching tabs doesn't refetch. Falls back to canned queries (`"new music"`, `"indie mix"`, …) when signed out. Hosts `DiceCard` — the random-shuffle wheel. |
-| `AlbumView.tsx` | Album header + track list, save/unsave, play-all, per-track context menu. |
-| `ArtistView.tsx` | Artist header, subscribe toggle, popular songs, all songs, releases, playlists. Subscription state has a 60 s optimistic override because the remote value lags. |
-| `PlaylistView.tsx` | Paginated track list (`getPlaylistTrackPage` with a page-key session cached 10 min), in-page search filter, drag reorder for local playlists, remove-from-playlist. |
-| `SearchResultsPage.tsx` | Mixed results grouped by artists / tracks / albums / playlists, painted incrementally from streaming `onUpdate` callbacks. |
-| `LyricsView.tsx` | Overlay. Synced lyrics scroll to the active line based on player position; falls back to plain text when timing is `estimated`/`none`. |
-| `SettingsPage.tsx` | Six sections — Account, Last.fm, About, System, Keyboard shortcuts, Window controls, Behavior. Covers sign-in/out, scrobbling, version + update check, cache size and clearing, local music folders (`dialog:open` → `local_audio_scan`), shortcut rebinding, decoration/control style, autostart, mini player, Paper-PC mode, geometry persistence, log file access, and "delete all app data". |
+| `HomePage.tsx` | Recently played, `HomeDestinations`, a `CylinderCarousel` of picks, and generated suggestions memoized per tab in module-level `Map`s so switching tabs doesn't refetch. Falls back to canned queries when signed out. Sections are toggleable (`homeSections.ts`). |
+| `LibraryPage.tsx` | The whole saved library in one view — playlists, albums, artists, songs. |
+| `BrowsePage.tsx` | The non-search surfaces through `getBrowsePage` — `explore` / `charts` / `moods` / `podcasts`, plus the local `downloads` list. Which one opens is carried on `Tab.browseTab`. |
+| `HistoryPage.tsx` | Local play log from `player/playHistory.ts`, with per-entry removal and clear-all. |
+| `AlbumView.tsx` | Album header + track list, save/unsave, play-all, download-all, per-track context menu. |
+| `ArtistView.tsx` | Artist header, subscribe toggle and notification level, popular songs, all songs, releases, playlists. Subscription state has a 60 s optimistic override because the remote value lags. |
+| `PlaylistView.tsx` | Paginated track list (`getPlaylistTrackPage`, page-key session cached), in-page search filter, multi-select, drag reorder, rename/describe/delete, import/export, remove-from-playlist. |
+| `RelatedPage.tsx` | `getRelated` shelves for a single track. |
+| `SearchResultsPage.tsx` | Mixed results grouped by artists / tracks / albums / playlists, painted incrementally from streaming `onUpdate` callbacks, with per-category drill-down. |
+| `LyricsView.tsx` | Overlay. Synced lyrics scroll to the active line; per-track timing offset, font scale, translation, and a source-attempt trail. Whether a karaoke highlight runs is decided by `lyricsTiming.ts` from the lines themselves, not from the provider's `timing` field — one line without a start time makes the highlight jump backwards. |
+| `SettingsPage.tsx` | Six tabs: **Account** (sign-in, accounts, Last.fm, Discord, updates, delete all data), **Appearance** (theme light/dark/system, Paper-PC mode, made-for-you sections), **Playback** (streaming/download quality, gapless, crossfade, transitions, lyrics translation/size/source), **Library** (cache size and clearing, local music folders via `dialog:open` → `local_audio_scan`, downloads ceiling), **Window** (decorations, control style, mini player, sidebar mode, tray, geometry, session restore, autostart), **Shortcuts** (rebinding). |
+| `collectTrackPages.ts` | Pages a track list to the end. Extracted from the views because the loop's *termination* is what fails quietly — a cursor that stops advancing spins forever (`collectTrackPages.check.ts`). |
 | `pageSearchKeyboard.ts` | `shouldStartPageSearch()` — see §2. |
 
 ---
@@ -169,14 +210,29 @@ and `storage` (for cross-window sync). Writes go to localStorage **and** durable
 
 | Module | Setting(s) |
 |---|---|
-| `keyboardShortcuts.ts` | Full remappable map for 19 actions (`playPause`, `mute`, `previousTrack`, `nextTrack`, `newTab`, `closeTab`, `search`, `navigateBack/Forward`, `tab1`–`tab9`), with `eventMatchesShortcut` and platform-aware modifier labels (⌘ vs Ctrl). |
-| `miniPlayer.ts` | Enabled flag, saved position (debounced), hover action, `resetMiniPlayerPosition()`. |
+| `theme.ts` | `system` / `light` / `dark`, written as `data-theme` before React mounts. `system` keeps following the OS via a `matchMedia` listener rather than resolving once at startup. |
+| `keyboardShortcuts.ts` | Remappable map for 19 actions, with `eventMatchesShortcut` and platform-aware modifier labels (⌘ vs Ctrl). |
+| `miniPlayer.ts` | Enabled flag, saved position (debounced), hover action, `resetMiniPlayerPosition()`, window create/destroy. |
 | `mainWindowGeometry.ts` | Size + position persistence with a min-size guard (900×600) and monitor-bounds validation; toggleable, and clears the stored value when disabled. |
 | `windowControls.ts` | `native-window-controls` (default on for Linux) and `windows-style-window-controls`; applies `setDecorations()` and toggles `data-native-window-controls`. |
 | `paperPcMode.ts` | Low-end mode: kills animations, transitions, shadows, and backdrop filters via `data-paper-pc`. Reloads on Linux where blur can't be toggled live. |
-| `playerControls.ts` | Player bar control visibility preferences. |
-| `lastfm.ts` | Scrobbling enabled flag + connection state. |
+| `sidebarMode.ts` | `collapsed` (62px) / `expanded` (240px) / `hover` — default `hover`. |
+| `queuePanel.ts` | Queue collapsed to an artwork rail vs full list. Defaults to collapsed. |
+| `toolbarItems.ts` | Which optional buttons the title bar carries. |
+| `homeSections.ts` | Which optional sections the home page carries. |
+| `playerControls.ts` | Compact vs expanded player bar; whether extra controls are always visible. |
+| `playbackTransitions.ts` | Gapless flag and crossfade seconds, backed by `player/playbackSettings.ts`. |
+| `sessionRestore.ts` | Whether tabs and queues come back after a restart. Read synchronously at boot, so the hydrate only backfills a cleared localStorage — it takes effect from the next launch. |
+| `tray.ts` | `minimize-to-tray`; the one setting Rust reads out of `settings-v1.json` itself. |
+| `lyricsTranslation.ts` | Target language or `off`. Off by default and off is a real value: translation sends the words of whatever is playing to a third-party endpoint, so it happens because someone asked. |
+| `lyricsFontScale.ts` | A multiplier, not a size set — the underlying scale is a container-width `clamp()`, and fixed sizes would throw that away. |
+| `lyricsOffset.ts` | Per-track timing nudge. LRCLIB matches on title/artist/±2 s duration, which is loose enough to return a different master whose words land a second off. |
+| `lastfm.ts` / `discord.ts` | Scrobbling and rich-presence enable flags + connection state. |
 | `autostart.ts` | `tauri-plugin-autostart` enable/disable/isEnabled. |
+
+Non-`ui/settings` siblings that follow the same contract: `internal/audioQuality.ts` (streaming and
+download caps set independently — the reason to cap one is not the reason to cap the other) and
+`internal/lyricsSourcePreference.ts`.
 
 ---
 
@@ -184,12 +240,18 @@ and `storage` (for cross-window sync). Writes go to localStorage **and** durable
 
 | Export | Source | Purpose |
 |---|---|---|
-| `usePlayerState()` | `player/playerStore.ts` | Effective player's `PlayerState` (status, current track, history, order mode, volume, muted) |
+| `usePlayerState()` | `player/playerStore.ts` | Effective player's `PlayerState` (status, current track, history, order mode, shuffle, volume, muted) |
+| `usePlayerSelector(select)` | same | Narrowed slice compared with `shallowEqual` — the preferred hook; the whole state object re-renders far more than any one component needs |
 | `usePlayerSession()` | same | Full session snapshot including the queue |
-| `useLibraryState()` | same | `LibraryController` state (status, library snapshot, auth prompt, pending likes) |
+| `useLibraryState()` | same | `LibraryController` state (status, snapshot, auth prompt, auth progress, pending likes, `sessionConfirmedAt`) |
 | `usePlayerUIState()` | `ui/stores/playerUIStore.ts` | Transient UI: `isSeeking`, `isDraggingVolume`, `showAlbumArt`, `isLyricsOpen`, `isQueueOpen` |
+| `useAmbientArtwork()` | `ui/stores/ambientArtworkStore.ts` | Artwork the current page wants the chrome tinted by. The page publishes, `Layout` subscribes — the wash starts above the search bar but the page that knows the artwork renders below it, inside a clipping scroll container |
+| `useOfflineState()` | `player/offlineStore.ts` | Download manifest, statuses and progress |
+| `usePlayHistory()` | `player/playHistory.ts` | Local play log |
+| `useNowPlaying()` | `ui/hooks/` | Just the primitives a collection page needs to mark rows, so `TrackRow`'s memo stays cheap |
+| `useTrackSelection()` | `ui/hooks/` | Multi-select modelled on file managers: ctrl/cmd toggles, shift extends from the last row touched, a plain click does nothing to the selection |
 | `useDisableContextMenu()` | `ui/hooks/` | Suppresses the native WebView context menu app-wide |
-| `isMacOS` / `isLinux` / `isWindows`, `primaryModifierLabel`, `hasPrimaryModifierOnly()` | `ui/platform.ts` | UA-based platform detection |
+| `isMacOS` / `isLinux` / `isWindows`, `primaryModifierLabel` | `ui/platform.ts` | UA-based platform detection |
 
 `playerController` (from `playerStore`) is the facade any component should call — it always resolves
 to the correct tab's `PlayerController` and claims playback ownership when starting new audio.
@@ -199,38 +261,47 @@ to the correct tab's `PlayerController` and claims playback ownership when start
 ## 7. Styling
 
 **Tailwind CSS v4** via `@tailwindcss/vite`, with one global sheet at `ui/styles/global.css`.
-There are no CSS Modules — all 33 `*.module.css` files were deleted in the beUI migration.
+Inter is self-hosted through `@fontsource-variable/inter` — this is an offline desktop app, and a
+CDN webfont that fails leaves the UI on a fallback face. `docs/` is excluded from Tailwind's source
+scan (the reference dumps in there are full of class names the app never uses).
 
 - **Design tokens live in a Tailwind `@theme` block** and follow shadcn naming, because that is
   what the vendored beUI components are written against: `--color-background`, `--color-foreground`,
   `--color-card`, `--color-popover`, `--color-muted` / `--color-muted-foreground`, `--color-border`,
-  `--color-input`, `--color-ring`, `--color-destructive`, and `--color-primary`.
+  `--color-input`, `--color-ring`, `--color-destructive`, `--color-secondary`, `--color-primary`.
 - The palette is **neutral shadcn surfaces + the app's `#ff0033` as `--color-primary`**. Red is an
-  accent only — use `bg-primary` / `text-primary` for play state, active tabs and primary actions,
-  never for large surfaces.
-- `:root` keeps only two non-colour constants, read from TSX as `var(--titlebar-height)` and
-  `var(--sidebar-width)`.
+  accent only — `bg-primary` / `text-primary` for play state, active tabs and primary actions,
+  never for large surfaces. It stays `#ff0033` in both themes: it's the brand accent, not a surface.
+- The UI is **borderless** — surfaces are separated by background contrast, not outlines.
+  `--color-border` / `--color-input` exist only because beUI internals reference them.
+- Non-colour `:root` constants: `--ambient-bloom` (strength of the accent wash behind the window,
+  a token because the same wash reads as a glow over near-black and a stain over near-white),
+  `--window-edge` / `--window-edge-highlight` (the window is transparent with its OS shadow
+  disabled, so a hairline is the only thing separating the app from what's behind it),
+  `--titlebar-height`, `--sidebar-width`.
 - Global resets beyond Tailwind preflight: `body { overflow: hidden }`, scrollbars zeroed out
   (`Layout.tsx` draws its own transient scrollbar), text selection disabled except in inputs,
   focus rings only on `:focus-visible`.
 - **Theme/behaviour switches are HTML attributes**, not classes:
-  - `html[data-paper-pc]` — overrides the `@theme` colours with fully opaque equivalents and kills
-    animation, box-shadow and backdrop-filter. Note this only stops *CSS* animation; beUI's
-    JS-driven motion is stopped by the `<MotionConfig reducedMotion>` bridge in `App.tsx`.
+  - `html[data-theme="light" | "dark"]` — the `@theme` block is the dark default; the light block
+    flips the same token names, so every component follows without knowing a theme exists.
+  - `html[data-paper-pc]` — overrides the colours with fully opaque equivalents and kills
+    animation, box-shadow and backdrop-filter. That only stops *CSS* animation; beUI's JS-driven
+    motion is stopped by the `<MotionConfig reducedMotion>` bridge in `App.tsx`.
   - `html[data-platform-linux]` — disables backdrop filters (WebKitGTK performance).
   - `html[data-native-window-controls]` — hides the custom window buttons.
-- Dark-only. There is no light theme.
 
 ### Component vocabulary
 
 Animated primitives are vendored from the [beUI](https://beui.dev) registry into
-`src/components/motion/` and `src/components/blocks/`, with shared helpers in `src/lib/`
-(`cn`, `ease`, `use-hover-capable`). They are kept at the registry's own paths so a future
-re-pull drops in without rewriting imports. App-owned components stay in `src/ui/`.
+`src/components/motion/`, with shared helpers in `src/lib/` (`cn`, `ease`, `use-hover-capable`).
+They are kept at the registry's own paths so a future re-pull drops in without rewriting imports.
+App-owned components stay in `src/ui/`. `@` is aliased to `src/`, so beUI's `@/components/...`
+imports resolve unchanged.
 
-In use: `button` (base/stateful/magnetic), `tooltip`, `tabs`, `drawer`, `input`, `loader`,
-`marquee`, `tilt-card`, `popover`, `command-palette`, `center-morph-modal`, `bouncy-accordion`,
-`bounce-sidebar`, `range-slider`, `shader-background`, `action-swap`.
+Vendored: `action-swap`, `bounce-sidebar`, `bouncy-accordion`, `button` (base/stateful/magnetic),
+`center-morph-modal`, `command-palette`, `cylinder-carousel`, `drawer`, `input`, `loader`,
+`magnetic`, `marquee`, `popover`, `range-slider`, `select`, `switch`, `tabs`, `tilt-card`, `tooltip`.
 
 **When re-pulling from the registry**, run the de-lucide pass afterwards — beUI ships
 `lucide-react` imports for its default icons, and this project uses Solar exclusively.
@@ -238,14 +309,16 @@ In use: `button` (base/stateful/magnetic), `tooltip`, `tabs`, `drawer`, `input`,
 ### Icons
 
 All icons come from `@solar-icons/react` (pinned to `2.0.0-beta.0` — the v2 API does not exist on
-the `latest` 1.x line) and are re-exported from **`src/ui/icons.tsx`**. Components import only from
-there, never from `@solar-icons/react` directly, so a renamed upstream icon breaks one file.
+the `latest` 1.x line) and are re-exported from **`src/ui/icons.tsx`** (~86 exports). Components
+import only from there, never from `@solar-icons/react` directly, so a renamed upstream icon breaks
+one file. Single-icon import paths are used deliberately: the style barrel makes the dev server
+resolve ~1.2k modules per style.
 
-Convention: the default export is Solar **Linear** (resting/secondary state); a `*ActiveIcon`
-alias is Solar **Bold** (active/primary — playing, liked, saved, selected). The weight change
-*is* the state signal. Solar ships no brand icons, so `LastFmIcon` stays a hand-rolled inline SVG.
-
-Solar icons take `strokeWidth`, not the raw SVG `stroke` attribute.
+Convention (see [solarIcons.md](./solarIcons.md)): the default export is Solar **Linear**
+(resting/secondary state); a `*ActiveIcon` alias is Solar **Bold** (active/primary — playing, liked,
+saved, selected). The weight change *is* the state signal. Solar ships no brand icons, so
+`LastFmIcon` stays a hand-rolled inline SVG. Solar icons take `strokeWidth`, not the raw SVG
+`stroke` attribute.
 
 ---
 
@@ -254,6 +327,9 @@ Solar icons take `strokeWidth`, not the raw SVG `stroke` attribute.
 - **Feature-detect optional data-source methods** (`this.dataSource.getLyrics?.(...)`) instead of assuming.
 - **Guard async work with request ids** — the codebase uses this everywhere for cancellation; a bare `await` that then calls `setState` is a bug waiting for a fast click.
 - **Two-tier settings**: never write only to localStorage; use the `durableLocalSetting` helpers so the value survives a WebView data reset.
+- **Prefer `usePlayerSelector` over `usePlayerState`**, and subscribe at the leaf that needs the value — `VolumeSyncBridge` exists solely because subscribing to volume at the root re-rendered the tree on every pointer move.
+- **`memo` with `propsEqual`, not the default**, for row components handed inline arrows — and route the handlers through a ref so it stays correct.
 - **Log through `internal/logging.ts`**, never raw `console.*` — it redacts secrets and mirrors to the on-disk log.
-- **New Tauri command?** Add it to `src-tauri/capabilities/default.json` or the call silently fails.
+- **Non-trivial pure logic gets a `*.check.ts`** next to it, run by `npm run check`. That is the whole frontend test story; there is no component harness.
 - **Optimistic mutations roll back**: `LibraryController` snapshots the previous library, applies the change, and restores on error. Match that pattern for new mutations.
+- **New Tauri command?** Register it in `generate_handler!` — that is sufficient. The `command.allow` list in `capabilities/default.json` is Tauri 1 leftover and gates nothing (see [backend.md](./backend.md) §4).

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -17,7 +17,7 @@ Runs before React mounts, in this order:
 3. `applyTheme()` + `watchSystemTheme()` — sets `data-theme`; `system` keeps following the OS rather than resolving once.
 4. `applyPaperPcMode()` / `applyNativeWindowControls()` — synchronous theme + decoration flags from localStorage.
 5. `hydrateMainWindowGeometry()` → `restoreMainWindowGeometry()`.
-6. `Promise.all` of ~17 `hydrate*` functions (paperPc, theme, windowControls, miniPlayer, playerControls, queuePanel, tray, audioQuality, lastFm, discord, sidebar, keyboardShortcuts, toolbarItems, homeSections, playbackSettings, playHistory, sessionRestore) — these reconcile localStorage against Rust-owned durable settings.
+6. `Promise.all` of ~18 `hydrate*` functions (paperPc, theme, windowControls, miniPlayer, playerControls, queuePanel, tray, audioQuality, audioEngineMode, lastFm, discord, sidebar, keyboardShortcuts, toolbarItems, homeSections, playbackSettings, playHistory, sessionRestore) — these reconcile localStorage against Rust-owned durable settings.
 7. `DiscordRpcService.init()`.
 8. `window.error` + `window.unhandledrejection` → `logInternalError`.
 9. `createRoot().render(<StrictMode><ErrorBoundary label="Zuno"><App/></ErrorBoundary></StrictMode>)` — the outermost boundary exists because a desktop shell has no address bar to reload a blank window from.
@@ -32,7 +32,7 @@ controllers — all state arrives over Tauri events from the main window.
 
 ## 2. `App.tsx` — the root
 
-2161 lines, the only component with meaningful state. It owns:
+2150 lines, the only component with meaningful state. It owns:
 
 | Concern | State / refs |
 |---|---|
@@ -42,8 +42,16 @@ controllers — all state arrives over Tauri events from the main window.
 | Onboarding | `onboardingStep`, keychain notice, completion toast |
 | Updates | `availableUpdate`, snooze handling, release note dialog |
 | Loading screen | `loadingScreenState`, min 1000 ms / max 4000 ms, 80 ms fade |
-| Mini player | positioning, focus-driven show/hide, suppression windows during drags |
+| Mini player | positioning, focus-driven create/destroy, suppression windows during drags |
 | Recovery | sleep detection (15 s timer, 60 s drift threshold) → reload; connection recovery on window focus |
+| Session persistence | an effect on `[tabs, activeTabId, nextTabId, playerSession]`, `beforeunload`, and a `SESSION_HEARTBEAT_MS` (5 s) heartbeat |
+
+**On that heartbeat:** the effect and `beforeunload` are the real persistence path; the timer only
+keeps `positionSec` fresh for a restore after a crash or a kill. It ran every second, rebuilding
+every tab's full queue and history into a multi-megabyte object graph, stringifying it and writing
+it synchronously — for a field that only has to be roughly right. At five seconds a hard kill costs
+at most five seconds of position, and `saveAppSession` skips the write outright when the payload is
+unchanged.
 
 Every page below it is `lazy`-loaded behind `Suspense`. Only Home is reachable at startup; the
 chunks come off local disk in a Tauri app, so the win is startup parse/compile time rather than
@@ -131,7 +139,7 @@ Tailwind classes inline; there are no `*.module.css` files.
 | Component | Purpose |
 |---|---|
 | `SearchOverlay.tsx` | ⌘/Ctrl+K palette. Fuzzy-scores your playlists/albums locally (`searchMatchScore`: exact 4 → prefix 3 → contains 2 → reverse-contains 1, with NFKD-normalized fallbacks), fetches remote suggestions, keeps recent searches, and recognises a pasted YouTube link (`looksLikeYouTubeLink`) to resolve rather than search. Shift-Enter opens results in a new tab. |
-| `TrackRow.tsx` | The one row used by every track list. `memo`'d with `propsEqual`, which ignores handler identity — comparing inline arrows with `Object.is` meant the memo never returned true and did nothing at all, rebuilding 500 rows to repaint two. Handlers are invoked through a ref refreshed each render, which is what makes that safe. |
+| `TrackRow.tsx` | The one row used by every track list. `memo`'d with `propsEqual`, which ignores handler identity — comparing inline arrows with `Object.is` meant the memo never returned true and did nothing at all, rebuilding 500 rows to repaint two. Handlers are invoked through a ref refreshed each render, which is what makes that safe. Also carries `content-visibility: auto` with `contain-intrinsic-size: auto 52px`, so off-screen rows skip layout, paint and compositing — see §8. |
 | `TrackContextMenu.tsx` | React context provider + menu: like/dislike, play next, add to queue, add to playlist (with submenu and pending state), remove from playlist, download/remove download, edit tags (local files), copy link, search artist, go to related. Viewport-edge flipping via `useLayoutEffect`. |
 | `PlaylistContextMenu.tsx` | Same pattern for playlists/albums: play, save/unsave, rename/describe/delete, local-playlist management, import/export, download all, remove. |
 | `SelectionBar.tsx` | Bulk actions for a multi-selection, floating above the player bar so it doesn't push the list around as it appears. |
@@ -173,7 +181,7 @@ Tailwind classes inline; there are no `*.module.css` files.
 
 A transparent always-on-top pill in its own window (~1.1k lines).
 
-- Appears on `main-window-backgrounded` / `main-window-minimized`, hides on `window-focused`.
+- Created on `main-window-backgrounded` / `main-window-minimized`, **destroyed** on `window-focused`. Its own close button calls `win.destroy()` for the same reason. `handleRestore` raises the main window without awaiting its own `hide()`: the main window answers `mini-player:restore-main` by destroying this one, so an awaited self-call can reject after the window is gone and abort the restore.
 - Expands on hover into a two-pill layout with transport controls.
 - Right-mouse or empty-area drag moves the window; the position is debounced into settings and echoed as `mini-player:position-changed`.
 - Hover behaviour over the progress area is configurable: `seek` or `volume` (`mini-player-hover-action`).
@@ -185,7 +193,7 @@ A transparent always-on-top pill in its own window (~1.1k lines).
 
 | Page | Notes |
 |---|---|
-| `HomePage.tsx` | Recently played, `HomeDestinations`, a `CylinderCarousel` of picks, and generated suggestions memoized per tab in module-level `Map`s so switching tabs doesn't refetch. Falls back to canned queries when signed out. Sections are toggleable (`homeSections.ts`). |
+| `HomePage.tsx` | Recently played, `HomeDestinations`, a `CylinderCarousel` of picks, and generated suggestions memoized in a module-level `Map` (20 entries, LRU) keyed by tab *and* a signature of the recently-played list. The key is computed above the `useState` calls so the initial render can read it — seeding from `tabId` alone meant the memo never hit and Home opened on a spinner every time. Falls back to canned queries when signed out. Sections are toggleable (`homeSections.ts`). |
 | `LibraryPage.tsx` | The whole saved library in one view — playlists, albums, artists, songs. |
 | `BrowsePage.tsx` | The non-search surfaces through `getBrowsePage` — `explore` / `charts` / `moods` / `podcasts`, plus the local `downloads` list. Which one opens is carried on `Tab.browseTab`. |
 | `HistoryPage.tsx` | Local play log from `player/playHistory.ts`, with per-entry removal and clear-all. |
@@ -195,7 +203,7 @@ A transparent always-on-top pill in its own window (~1.1k lines).
 | `RelatedPage.tsx` | `getRelated` shelves for a single track. |
 | `SearchResultsPage.tsx` | Mixed results grouped by artists / tracks / albums / playlists, painted incrementally from streaming `onUpdate` callbacks, with per-category drill-down. |
 | `LyricsView.tsx` | Overlay. Synced lyrics scroll to the active line; per-track timing offset, font scale, translation, and a source-attempt trail. Whether a karaoke highlight runs is decided by `lyricsTiming.ts` from the lines themselves, not from the provider's `timing` field — one line without a start time makes the highlight jump backwards. |
-| `SettingsPage.tsx` | Six tabs: **Account** (sign-in, accounts, Last.fm, Discord, updates, delete all data), **Appearance** (theme light/dark/system, Paper-PC mode, made-for-you sections), **Playback** (streaming/download quality, gapless, crossfade, transitions, lyrics translation/size/source), **Library** (cache size and clearing, local music folders via `dialog:open` → `local_audio_scan`, downloads ceiling), **Window** (decorations, control style, mini player, sidebar mode, tray, geometry, session restore, autostart), **Shortcuts** (rebinding). |
+| `SettingsPage.tsx` | Six tabs: **Account** (sign-in, accounts, Last.fm, Discord, updates, delete all data), **Appearance** (theme light/dark/system, Paper-PC mode, made-for-you sections), **Playback** (audio engine, streaming/download quality, gapless, crossfade, transitions, lyrics translation/size/source), **Library** (cache size and clearing, local music folders via `dialog:open` → `local_audio_scan`, downloads ceiling), **Window** (decorations, control style, mini player, sidebar mode, tray, geometry, session restore, autostart), **Shortcuts** (rebinding). |
 | `collectTrackPages.ts` | Pages a track list to the end. Extracted from the views because the loop's *termination* is what fails quietly — a cursor that stops advancing spins forever (`collectTrackPages.check.ts`). |
 | `pageSearchKeyboard.ts` | `shouldStartPageSearch()` — see §2. |
 
@@ -212,7 +220,8 @@ and `storage` (for cross-window sync). Writes go to localStorage **and** durable
 |---|---|
 | `theme.ts` | `system` / `light` / `dark`, written as `data-theme` before React mounts. `system` keeps following the OS via a `matchMedia` listener rather than resolving once at startup. |
 | `keyboardShortcuts.ts` | Remappable map for 19 actions, with `eventMatchesShortcut` and platform-aware modifier labels (⌘ vs Ctrl). |
-| `miniPlayer.ts` | Enabled flag, saved position (debounced), hover action, `resetMiniPlayerPosition()`, window create/destroy. |
+| `miniPlayer.ts` | Enabled flag, saved position (debounced), hover action, `resetMiniPlayerPosition()`. Owns the window's whole lifecycle: `ensureMiniPlayerWindow()` / `destroyMiniPlayerWindow()` run through one serialized promise chain so a blur/focus pair can't interleave into an orphaned or prematurely-destroyed window. |
+| `audioEngine.ts` | `iframe` (default) vs `native` playback. The value is cached in-module because `AudioEngine` reads it on every load, play, pause, seek and volume change — a raw localStorage hit would sit in the playback path. Exports `AUDIO_ENGINE_MODE_CHANGE_EVENT` so the engine can free its IFrame decks the moment the mode stops being `iframe`. |
 | `mainWindowGeometry.ts` | Size + position persistence with a min-size guard (900×600) and monitor-bounds validation; toggleable, and clears the stored value when disabled. |
 | `windowControls.ts` | `native-window-controls` (default on for Linux) and `windows-style-window-controls`; applies `setDecorations()` and toggles `data-native-window-controls`. |
 | `paperPcMode.ts` | Low-end mode: kills animations, transitions, shadows, and backdrop filters via `data-paper-pc`. Reloads on Linux where blur can't be toggled live. |
@@ -272,6 +281,16 @@ scan (the reference dumps in there are full of class names the app never uses).
 - The palette is **neutral shadcn surfaces + the app's `#ff0033` as `--color-primary`**. Red is an
   accent only — `bg-primary` / `text-primary` for play state, active tabs and primary actions,
   never for large surfaces. It stays `#ff0033` in both themes: it's the brand accent, not a surface.
+- **Never put `backdrop-blur` on an opaque background.** `--color-background`, `--color-card` and
+  `--color-popover` have no alpha in either theme, so a backdrop filter behind them costs a
+  composited layer and a blur pass to render something nothing can see through. Seven always-on
+  surfaces carried one — the content pane, title bar, sidebar, player bar, search field, right
+  panel and queue header — and removing them changed nothing visually. Blur belongs only on a
+  translucent fill (`bg-card/60`, `bg-background/70`).
+- **Blur radius sizes the compositor's intermediate textures**, so the two always-on filters are
+  kept modest: the ambient wash at `blur-[32px]` (its source is a 120px image stretched to full
+  width — a ~20x upscale is already most of the softness) and StarField's blobs at `blur-2xl`
+  (they are `rounded-full` gradients fading to transparent, so the fill does the work).
 - The UI is **borderless** — surfaces are separated by background contrast, not outlines.
   `--color-border` / `--color-input` exist only because beUI internals reference them.
 - Non-colour `:root` constants: `--ambient-bloom` (strength of the accent wash behind the window,
@@ -329,6 +348,8 @@ saved, selected). The weight change *is* the state signal. Solar ships no brand 
 - **Two-tier settings**: never write only to localStorage; use the `durableLocalSetting` helpers so the value survives a WebView data reset.
 - **Prefer `usePlayerSelector` over `usePlayerState`**, and subscribe at the leaf that needs the value — `VolumeSyncBridge` exists solely because subscribing to volume at the root re-rendered the tree on every pointer move.
 - **`memo` with `propsEqual`, not the default**, for row components handed inline arrows — and route the handlers through a ref so it stays correct.
+- **The track lists are not windowed, deliberately.** `PlaylistView`, `AlbumView`, `SearchResultsPage`, `HistoryPage` and `QueuePanel` all map the full array; the `IntersectionObserver` in `PlaylistView` is infinite-scroll paging, not virtualization. Windowing fights two features that need the whole index space — drag-reorder (the dragged row must survive scrolling out of range) and `useTrackSelection`'s shift-range. `content-visibility: auto` on `TrackRow` buys most of the rendering win for one line instead: the nodes stay, the work does not. Use `contain-intrinsic-size` with the `auto` keyword so the browser prefers the height it last measured and the literal only covers rows never yet on screen.
+- **Bound every module-level cache.** `artworkCache` (16 MB of blobs, 500 entries), `HomePage`'s `suggestionCache` (20 entries), `playHistory` (500), `playlistMembership` (1000) all evict oldest-first. A `Map` keyed by anything that varies with use — a tab id, a search key, a recently-played signature — grows for as long as the app is open.
 - **Log through `internal/logging.ts`**, never raw `console.*` — it redacts secrets and mirrors to the on-disk log.
 - **Non-trivial pure logic gets a `*.check.ts`** next to it, run by `npm run check`. That is the whole frontend test story; there is no component harness.
 - **Optimistic mutations roll back**: `LibraryController` snapshots the previous library, applies the change, and restores on error. Match that pattern for new mutations.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,7 +9,7 @@ use std::fs::{self, File, OpenOptions};
 use std::io::{Read, Write};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, TcpListener};
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
@@ -1929,6 +1929,9 @@ struct ProxyHttpResponse {
 struct MediaItem {
     bytes: Arc<Vec<u8>>,
     mime_type: String,
+    /// Insertion order, for evicting the coldest entry. A counter rather than a timestamp:
+    /// two inserts inside the same millisecond still have to be orderable.
+    sequence: u64,
 }
 
 struct MediaServer {
@@ -1945,6 +1948,61 @@ struct AudioSourcePayload {
 }
 
 static MEDIA_SERVER: OnceLock<MediaServer> = OnceLock::new();
+static MEDIA_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+/**
+ * Audio bodies held in memory at once.
+ *
+ * Two is the real working set — the track playing, and the one preloaded behind it — with a
+ * third as slack for a fast skip that starts a fourth before the first has been let go. Each
+ * entry is a whole song, so a slot costs megabytes: this is a cap, not a cache.
+ */
+const MEDIA_SERVER_MAX_ITEMS: usize = 3;
+
+/**
+ * Publishes a body under `key`, evicting the coldest entries to stay under the cap.
+ *
+ * The eviction is the point. This map was insert-only, so with native audio on, every track
+ * ever played stayed resident for the life of the process — a few megabytes per song, never
+ * returned.
+ *
+ * Replacing an existing key is safe mid-playback: `handle_media_request` clones the `Arc`
+ * before it writes, so a request already in flight finishes against the bytes it started with.
+ */
+fn store_media_item(
+    items: &Arc<Mutex<HashMap<String, MediaItem>>>,
+    key: String,
+    bytes: Vec<u8>,
+    mime_type: String,
+) -> Result<(), CommandError> {
+    let mut items = items.lock().map_err(|_| CommandError {
+        message: "media server cache lock poisoned".into(),
+    })?;
+
+    items.insert(
+        key,
+        MediaItem {
+            bytes: Arc::new(bytes),
+            mime_type,
+            sequence: MEDIA_SEQUENCE.fetch_add(1, Ordering::Relaxed),
+        },
+    );
+
+    while items.len() > MEDIA_SERVER_MAX_ITEMS {
+        let coldest = items
+            .iter()
+            .min_by_key(|(_, item)| item.sequence)
+            .map(|(key, _)| key.clone());
+        match coldest {
+            Some(key) => {
+                items.remove(&key);
+            }
+            None => break,
+        }
+    }
+
+    Ok(())
+}
 
 fn collect_json_renderer_counts(value: &serde_json::Value, counts: &mut HashMap<String, usize>) {
     match value {
@@ -2056,8 +2114,18 @@ fn handle_media_request(
     } else {
         String::new()
     };
+    /*
+     * `no-store` is load-bearing, not hygiene.
+     *
+     * Without it the webview keeps its own copy of every audio body it fetches — whole songs,
+     * several megabytes each, in the renderer process. That is memory this process is already
+     * holding, retained a second time by the one place that cannot be asked to give it back.
+     *
+     * The cost is that seeking backwards re-requests a range instead of reading the webview's
+     * copy. Over loopback against a `Vec<u8>` already in memory, that is a memcpy.
+     */
     let headers = format!(
-        "HTTP/1.1 {status}\r\nContent-Type: {}\r\nAccept-Ranges: bytes\r\n{}Content-Length: {body_len}\r\nConnection: close\r\n\r\n",
+        "HTTP/1.1 {status}\r\nContent-Type: {}\r\nAccept-Ranges: bytes\r\nCache-Control: no-store\r\n{}Content-Length: {body_len}\r\nConnection: close\r\n\r\n",
         item.mime_type,
         content_range,
     );
@@ -2517,18 +2585,7 @@ fn offline_audio_source(
 
     let server = media_server()?;
     let key = format!("offline-{track_id}");
-    {
-        let mut items = server.items.lock().map_err(|_| CommandError {
-            message: "media server cache lock poisoned".into(),
-        })?;
-        items.insert(
-            key.clone(),
-            MediaItem {
-                bytes: Arc::new(bytes),
-                mime_type: mime_type.clone(),
-            },
-        );
-    }
+    store_media_item(&server.items, key.clone(), bytes, mime_type.clone())?;
 
     Ok(AudioSourcePayload {
         url: format!("{}/audio/{}", server.origin, key),
@@ -2653,27 +2710,16 @@ async fn fetch_audio_source(
     }
 
     let server = media_server()?;
-    let key = format!(
-        "{}-{}",
-        track_id,
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map(|duration| duration.as_millis())
-            .unwrap_or_default()
-    );
+    /*
+     * Keyed by track alone. This used to carry a millisecond timestamp, which minted a fresh
+     * URL for every play — so a replay stored a second copy of the same song here, and the
+     * webview accumulated an entry per play under a URL it would never request again.
+     *
+     * Prefixed to keep this namespace clear of `offline_audio_source`'s.
+     */
+    let key = format!("stream-{track_id}");
     let byte_length = bytes.len();
-    {
-        let mut items = server.items.lock().map_err(|_| CommandError {
-            message: "media server cache lock poisoned".into(),
-        })?;
-        items.insert(
-            key.clone(),
-            MediaItem {
-                bytes: Arc::new(bytes),
-                mime_type: mime_type.clone(),
-            },
-        );
-    }
+    store_media_item(&server.items, key.clone(), bytes, mime_type.clone())?;
 
     Ok(AudioSourcePayload {
         url: format!("{}/audio/{}", server.origin, key),
@@ -3608,8 +3654,52 @@ mod tests {
     use super::{
         apply_set_cookie, audio_url_with_range, cookie_account_identity, cookie_domain_matches,
         is_slow_persist_cookie, is_youtube_cookie_host, parse_cookie_header, sanitize_log_url,
-        serialize_cookie_pairs, signed_content_length,
+        serialize_cookie_pairs, signed_content_length, store_media_item, MediaItem,
+        MEDIA_SERVER_MAX_ITEMS,
     };
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+
+    /// The guard on the leak: this map was insert-only, so every song ever played stayed in
+    /// memory for the life of the process.
+    #[test]
+    fn media_items_stay_capped_and_evict_the_coldest_first() {
+        let items: Arc<Mutex<HashMap<String, MediaItem>>> = Arc::new(Mutex::new(HashMap::new()));
+
+        for index in 0..MEDIA_SERVER_MAX_ITEMS + 3 {
+            store_media_item(
+                &items,
+                format!("stream-track{index}"),
+                vec![0_u8; 8],
+                "audio/mp4".into(),
+            )
+            .map_err(|error| error.message)
+            .expect("store succeeds");
+        }
+
+        let stored = items.lock().expect("lock");
+        assert_eq!(stored.len(), MEDIA_SERVER_MAX_ITEMS, "cap is not enforced");
+        // The newest survive; the first inserts are the ones that had to go.
+        assert!(stored.contains_key(&format!("stream-track{}", MEDIA_SERVER_MAX_ITEMS + 2)));
+        assert!(!stored.contains_key("stream-track0"));
+    }
+
+    /// A replay must reuse its slot rather than add a second copy of the same song — the other
+    /// half of the leak, caused by the key carrying a timestamp.
+    #[test]
+    fn restoring_the_same_track_replaces_rather_than_accumulates() {
+        let items: Arc<Mutex<HashMap<String, MediaItem>>> = Arc::new(Mutex::new(HashMap::new()));
+
+        for _ in 0..5 {
+            store_media_item(&items, "stream-same".into(), vec![7_u8; 4], "audio/mp4".into())
+                .map_err(|error| error.message)
+                .expect("store succeeds");
+        }
+
+        let stored = items.lock().expect("lock");
+        assert_eq!(stored.len(), 1);
+        assert_eq!(stored["stream-same"].bytes.len(), 4);
+    }
 
     /// The whole point of the jar: a rotated value replaces the stale one, a new value joins,
     /// an unchanged value reports no change, and a tombstone drops the cookie.

--- a/src/internal/artworkCache.ts
+++ b/src/internal/artworkCache.ts
@@ -28,7 +28,7 @@ const MAX_ENTRIES = 500;
  * nothing, and blobs, which cost whatever the image weighs. Five hundred thumbnails and five
  * hundred full-size covers are the same number and two orders of magnitude apart in bytes.
  */
-const MAX_BLOB_BYTES = 32 * 1024 * 1024;
+const MAX_BLOB_BYTES = 16 * 1024 * 1024;
 const MAX_PERSISTED_ENTRIES = 300;
 const STORAGE_KEY = "zuno:artwork-resolved-v1";
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -15,6 +15,7 @@ import { hydratePlayerControlSettings } from "./ui/settings/playerControls";
 import { hydrateQueuePanelSettings } from "./ui/settings/queuePanel";
 import { hydrateTraySettings } from "./ui/settings/tray";
 import { hydrateAudioQualitySettings } from "./internal/audioQuality";
+import { hydrateAudioEngineMode } from "./ui/settings/audioEngine";
 import { notifyLocalPlaylistsChanged, syncLocalAudioWatcher } from "./player/localPlaylists";
 import { listen } from "@tauri-apps/api/event";
 import { hydrateLastFmSettings } from "./ui/settings/lastfm";
@@ -56,6 +57,7 @@ void Promise.all([
   hydrateQueuePanelSettings(),
   hydrateTraySettings(),
   hydrateAudioQualitySettings(),
+  hydrateAudioEngineMode(),
   hydrateLastFmSettings(),
   hydrateDiscordSettings(),
   hydrateSidebarSettings(),

--- a/src/player/AudioEngine.ts
+++ b/src/player/AudioEngine.ts
@@ -1,4 +1,8 @@
 import { logInternalError, logInternalInfo, logInternalWarn } from "../internal/logging";
+import {
+  AUDIO_ENGINE_MODE_CHANGE_EVENT,
+  usesNativeAudioEngine,
+} from "../ui/settings/audioEngine";
 
 type YouTubePlayerEvent = {
   data: number;
@@ -69,11 +73,42 @@ const audioEngines = new Set<AudioEngine>();
 let playbackClaimId = 0;
 let playbackOwner: AudioEngine | null = null;
 
+/*
+ * Switching to native has to *free* the decks, not merely stop routing to them.
+ *
+ * Changing the setting only changes which branch `loadTrack` takes. Any player already built
+ * keeps its `youtube.com` subframe process alive — the whole ~90 MB the setting exists to give
+ * back — so without this the memory only drops once every tab happens to load another track.
+ *
+ * The engine currently making sound is spared: flipping a setting should not cut off the song
+ * that is playing. It releases at its next track, where `loadTrack`'s native branch does the
+ * same thing.
+ */
+if (typeof window !== "undefined") {
+  window.addEventListener(AUDIO_ENGINE_MODE_CHANGE_EVENT, () => {
+    if (!usesNativeAudioEngine()) return;
+    for (const engine of audioEngines) {
+      if (engine === playbackOwner) continue;
+      engine.releaseIframePlayer();
+    }
+  });
+}
+
+/*
+ * Follows the user's setting, read fresh rather than captured at construction.
+ *
+ * This was hardcoded `false` from v1.2.65: the backend download path answered 403 for remote
+ * streams, so every platform was reverted to the iframe player. What fixed it was PO tokens —
+ * the *download* feature has used this exact resolve-and-fetch path successfully ever since,
+ * which is what makes it safe to offer again. It stays opt-in because a signed URL is resolved
+ * and fetched before the first sample plays, so a track starts a little slower.
+ *
+ * Read per call so switching the setting takes effect on the next track rather than at the next
+ * launch. Mid-track it changes nothing: every branch that matters is `useNativeAudio || audio`,
+ * so a live `<audio>` element keeps being driven as one until it is released.
+ */
 function shouldUseNativeAudio(): boolean {
-  // Native audio playback is disabled for remote YouTube tracks because the
-  // backend download path can fail with 403 errors. v1.2.65 used the iframe
-  // player on every platform, including Linux.
-  return false;
+  return usesNativeAudioEngine();
 }
 
 function isPlayerStateTimeout(error: unknown): boolean {
@@ -128,7 +163,14 @@ function loadYouTubeIframeApi(): Promise<void> {
 }
 
 export class AudioEngine {
-  private readonly useNativeAudio = shouldUseNativeAudio();
+  /*
+   * A getter, not a field captured in the constructor: engines are built once per tab and live
+   * for the whole session, so a captured value would keep the old pipeline until relaunch.
+   */
+  private get useNativeAudio(): boolean {
+    return shouldUseNativeAudio();
+  }
+
   private player: YouTubePlayer | null = null;
   private playerHost: HTMLElement | null = null;
   private playerPromise: Promise<YouTubePlayer> | null = null;
@@ -184,6 +226,12 @@ export class AudioEngine {
       if (!audioData && !sourceUrl) {
         throw new Error("Native playback requires downloaded audio data.");
       }
+      /*
+       * The mirror of `releaseNativeAudio()` on the iframe branch below: whichever pipeline is
+       * not in use gives its resources back. This is also the point where the engine that was
+       * still sounding when the setting changed finally lets go of its subframe.
+       */
+      this.releaseIframePlayer();
       await this.loadNativeAudio(videoId, audioData, mimeType, sourceUrl);
       return;
     }
@@ -370,6 +418,40 @@ export class AudioEngine {
     this.cancelStandbyTeardown();
     this.destroyStandby();
     audioEngines.delete(this);
+  }
+
+  /**
+   * Frees the IFrame decks without disturbing the engine or any `<audio>` it is driving.
+   *
+   * Distinct from `dispose()`, which also stops playback and unregisters the engine. This
+   * leaves a working engine behind that simply builds a new player if the iframe path is asked
+   * for again — which is what switching the audio engine setting back and forth needs.
+   *
+   * The thing being reclaimed is not a DOM element. Each IFrame player holds a `youtube.com`
+   * subframe *process*; merely routing playback elsewhere leaves that ~90 MB resident, which is
+   * exactly the memory the native setting exists to give back.
+   */
+  releaseIframePlayer(): void {
+    if (!this.player && !this.playerPromise && !this.standbyHost) return;
+
+    this.cancelStandbyTeardown();
+    this.destroyStandby();
+
+    // Invalidates any cue or play still awaiting the deck being torn down, so a late resolve
+    // cannot write state for a player that no longer exists.
+    this.loadRequestId += 1;
+    this.player?.destroy();
+    this.playerHost?.remove();
+    this.player = null;
+    this.playerHost = null;
+    this.playerPromise = null;
+    /*
+     * Cleared so a later iframe load actually cues into the fresh player instead of
+     * short-circuiting on `currentVideoId === videoId`. Left alone when an `<audio>` element
+     * owns it — that is the native path's bookkeeping, not the deck's.
+     */
+    if (!this.audio) this.currentVideoId = null;
+    logInternalInfo("AudioEngine.releaseIframePlayer", {});
   }
 
   seekTo(seconds: number): void {

--- a/src/player/appSession.ts
+++ b/src/player/appSession.ts
@@ -48,9 +48,22 @@ export function loadAppSession(): AppSession | null {
   }
 }
 
+/**
+ * The payload last written, so an unchanged session costs a comparison rather than a write.
+ *
+ * The session is persisted from three places — a heartbeat, an effect watching the tabs and
+ * player session, and `beforeunload` — and most of those fire when nothing that actually gets
+ * persisted has moved. `localStorage.setItem` is synchronous and disk-backed, so skipping the
+ * no-op writes is worth more than the string comparison costs.
+ */
+let lastWrittenSession: string | null = null;
+
 export function saveAppSession(session: AppSession): void {
   try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(session));
+    const payload = JSON.stringify(session);
+    if (payload === lastWrittenSession) return;
+    localStorage.setItem(STORAGE_KEY, payload);
+    lastWrittenSession = payload;
   } catch {
     // Persistence failure should not interrupt playback.
   }
@@ -59,6 +72,8 @@ export function saveAppSession(session: AppSession): void {
 export function clearAppSession(): void {
   try {
     localStorage.removeItem(STORAGE_KEY);
+    // Or the next save would match the cleared value and decline to rewrite it.
+    lastWrittenSession = null;
   } catch {
     // Persistence failure should not interrupt a full reset.
   }

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -133,6 +133,8 @@ const MINI_PLAYER_BOTTOM_MARGIN = 24;
 // A long fixed timeout used to swallow the mini player when the window was moved
 // and then minimised shortly after.
 const MAIN_WINDOW_DRAG_BACKGROUND_SUPPRESS_MS = 1500;
+/** How often the session is written purely to keep the restored playback position fresh. */
+const SESSION_HEARTBEAT_MS = 5000;
 const SLEEP_RECOVERY_TIMER_INTERVAL_MS = 15000;
 const SLEEP_RECOVERY_TIMER_DRIFT_MS = 60000;
 const TAB_SHORTCUT_ACTIONS: KeyboardShortcutAction[] = [
@@ -728,8 +730,19 @@ export default function App() {
     };
   }, [dismissLoadingScreen, libraryState.library, libraryState.status, showKeychainNotice]);
 
+  /*
+   * A heartbeat, not the primary persistence path.
+   *
+   * Every change to the tabs or the player session is already written by the effect below, and
+   * `beforeunload` catches a clean exit. All this adds is `positionSec` freshness for a restore
+   * after a crash or a kill — so it ran every second, rebuilding every tab's full queue and
+   * history into a multi-megabyte object graph, stringifying it and writing it synchronously,
+   * for a field that only has to be roughly right.
+   *
+   * At five seconds a hard kill costs at most five seconds of playback position.
+   */
   useEffect(() => {
-    const intervalId = window.setInterval(persistAppSession, 1000);
+    const intervalId = window.setInterval(persistAppSession, SESSION_HEARTBEAT_MS);
     window.addEventListener("beforeunload", persistAppSession);
     return () => {
       window.clearInterval(intervalId);

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -408,7 +408,6 @@ export default function App() {
   }, []);
   const loadingScreenDismissedRef = useRef(false);
   const loadingScreenStartedAtRef = useRef(performance.now());
-  const miniPlayerPositionedRef = useRef(false);
   const miniPlayerEnabledRef = useRef(miniPlayerEnabled);
   const miniPlayerRestoreSuppressUntilRef = useRef(0);
   const mainWindowDragSuppressUntilRef = useRef(0);
@@ -1633,31 +1632,27 @@ export default function App() {
 
 
 /*
- * The window follows the setting, rather than existing always and merely being hidden.
+ * The window exists only while it is on screen.
  *
- * Enabled: created up front, so the first time it is needed — backgrounding the app — it appears
- * immediately rather than after a webview cold start. Disabled: destroyed, which is the only
- * thing that actually returns its ~32 MB; hiding leaves the process resident.
+ * It used to be created on mount and merely hidden on return, which left an idle WebView2
+ * renderer resident for the whole session — ~32 MB, plus its share of the shared GPU process,
+ * paid by everyone including the users who never background the app. Creation is deferred to
+ * the moment it is shown and the window is destroyed when the main window comes back; only
+ * destroying returns the memory.
+ *
+ * The cost is a cold webview start on each show. That is paid while the user is looking at
+ * another application, which is the one moment it does not read as lag.
  */
 useEffect(() => {
-  if (miniPlayerEnabled) {
-    void ensureMiniPlayerWindow();
-    return;
-  }
-
-  // The ref describes a window that is about to stop existing. Left set, the replacement made
-  // on re-enable would be treated as already placed and open wherever the OS put it.
-  miniPlayerPositionedRef.current = false;
+  if (miniPlayerEnabled) return;
   void destroyMiniPlayerWindow();
 }, [miniPlayerEnabled]);
 
 
 useEffect(() => {
   const setupListeners = async () => {
-    const hideMiniPlayer = async () => {
-      const miniWin = await WebviewWindow.getByLabel("mini-player");
-      if (miniWin) await miniWin.hide();
-    };
+    /** Destroys rather than hides: a hidden webview keeps its whole renderer process alive. */
+    const dismissMiniPlayer = () => destroyMiniPlayerWindow();
 
     /**
      * @param force bypasses the drag/restore suppression windows. Used for an explicit
@@ -1665,37 +1660,24 @@ useEffect(() => {
      */
     const showMiniPlayerIfAllowed = async (_event?: unknown, force = false) => {
       /*
-       * Checked before the window is asked for, not after.
+       * Every one of these is checked before the window is asked for, not after.
        *
-       * Asking is now what creates it, so testing `enabled` afterwards would spawn the window
-       * for the very users who turned it off, only to hide it again.
+       * Asking is what creates it, so a suppression tested afterwards would spawn a whole
+       * webview process only to tear it down again — which is the cost this window is
+       * lazily created to avoid in the first place.
        */
-      if (!miniPlayerEnabledRef.current) {
-        await hideMiniPlayer();
-        return;
-      }
+      if (!miniPlayerEnabledRef.current) return;
+      if (!force && Date.now() < mainWindowDragSuppressUntilRef.current) return;
+      if (!force && Date.now() < miniPlayerRestoreSuppressUntilRef.current) return;
 
-      // Covers the cold-start race: backgrounding the app in the first moments after launch
-      // can arrive before the creation kicked off on mount has finished.
       const miniWin = await ensureMiniPlayerWindow();
       if (!miniWin) return;
 
-      if (!force && Date.now() < mainWindowDragSuppressUntilRef.current) {
-        await miniWin.hide();
-        return;
-      }
-
-      if (!force && Date.now() < miniPlayerRestoreSuppressUntilRef.current) {
-        await miniWin.hide();
-        return;
-      }
-
-      if (!miniPlayerPositionedRef.current) {
-        try {
-          await placeMiniPlayerAtBottomCenter(miniWin);
-        } catch (_) {}
-        miniPlayerPositionedRef.current = true;
-      }
+      // Placed on every show, because every show is a new window. `placeMiniPlayerAtBottomCenter`
+      // prefers the saved position, so a window the user dragged still comes back where they left it.
+      try {
+        await placeMiniPlayerAtBottomCenter(miniWin);
+      } catch (_) {}
 
       await miniWin.show();
       if (isLinux) {
@@ -1706,20 +1688,17 @@ useEffect(() => {
       await miniWin.setFocus();
     };
 
+    /*
+     * Launching straight into the background — autostart, or a click elsewhere while the app
+     * was still starting — produces no blur event, because focus was never held to lose.
+     */
     const recoverMissedBackgroundEvent = async () => {
-      const [mainWin, miniWin] = await Promise.all([
-        WebviewWindow.getByLabel("main"),
-        WebviewWindow.getByLabel("mini-player"),
-      ]);
-      if (!mainWin || !miniWin) return;
+      if (!miniPlayerEnabledRef.current) return;
 
-      const [mainFocused, miniFocused] = await Promise.all([
-        mainWin.isFocused(),
-        miniWin.isFocused(),
-      ]);
-      if (!mainFocused && !miniFocused) {
-        await showMiniPlayerIfAllowed();
-      }
+      const mainWin = await WebviewWindow.getByLabel("main");
+      if (!mainWin || (await mainWin.isFocused())) return;
+
+      await showMiniPlayerIfAllowed();
     };
 
     const unlistenBackgrounded = await listen("main-window-backgrounded", () =>
@@ -1741,14 +1720,14 @@ useEffect(() => {
 
     const unlistenFocus = await listen("window-focused", () => {
       mainWindowDragSuppressUntilRef.current = 0;
-      void hideMiniPlayer();
+      void dismissMiniPlayer();
     });
     window.addEventListener("main-window-drag-started", handleMainWindowDragStarted);
     window.addEventListener("pointerup", handleMainWindowDragEnded);
     window.addEventListener("pointercancel", handleMainWindowDragEnded);
     const unlistenRestoreMain = await listen("mini-player:restore-main", async () => {
       miniPlayerRestoreSuppressUntilRef.current = Date.now() + 800;
-      await hideMiniPlayer();
+      await dismissMiniPlayer();
     });
     const unlistenPositionChanged = await listen<{ x: number; y: number }>(
       "mini-player:position-changed",
@@ -1757,9 +1736,6 @@ useEffect(() => {
       },
     );
 
-    if (!miniPlayerEnabledRef.current) {
-      await hideMiniPlayer();
-    }
     void recoverMissedBackgroundEvent();
 
     return () => {

--- a/src/ui/components/AlbumCard.tsx
+++ b/src/ui/components/AlbumCard.tsx
@@ -3,12 +3,23 @@ import { TiltCard } from "@/components/motion/tilt-card";
 import { PlayActiveIcon } from "@/ui/icons";
 import { TrackArtwork } from "./TrackArtwork";
 
+/**
+ * Rendered card width in CSS pixels.
+ *
+ * The default covers the `minmax(9rem…9.5rem, 1fr)` grids these sit in. It only has to land in
+ * the right size bucket, not be exact — a column stretched a little wider by `1fr` still
+ * resolves to the same request.
+ */
+const DEFAULT_CARD_SIZE = 176;
+
 interface AlbumCardProps {
   color?: string;
   artworkUrl?: string;
   title?: string;
   subtitle?: string;
   subtitleContent?: ReactNode;
+  /** Override when the card is laid out at a materially different width. */
+  size?: number;
   onClick?: () => void;
   onContextMenu?: (event: MouseEvent<HTMLDivElement>) => void;
 }
@@ -19,6 +30,7 @@ export function AlbumCard({
   title,
   subtitle,
   subtitleContent,
+  size = DEFAULT_CARD_SIZE,
   onClick,
   onContextMenu,
 }: AlbumCardProps) {
@@ -39,6 +51,7 @@ export function AlbumCard({
             className="size-full object-cover"
             artworkUrl={artworkUrl}
             iconSize={48}
+            size={size}
             variant="album"
           />
           {/* Play affordance fades in on hover rather than sitting permanently on the art. */}

--- a/src/ui/components/Layout.tsx
+++ b/src/ui/components/Layout.tsx
@@ -171,7 +171,9 @@ export function Layout({
           onNavigateAlbum={onNavigateAlbum}
           onNavigatePlaylist={onNavigatePlaylist}
         />
-        <div className="relative flex min-h-0 min-w-0 flex-1 flex-col gap-3 px-4 pt-3 bg-background backdrop-blur rounded-tl-lg">
+        {/* No backdrop-blur: `bg-background` is fully opaque, so a backdrop filter here costs a
+            composited layer and a blur pass to render something nothing can see through. */}
+        <div className="relative flex min-h-0 min-w-0 flex-1 flex-col gap-3 px-4 pt-3 bg-background rounded-tl-lg">
           {/*
             Ambient wash for the page beneath. Rendered here rather than inside the page so
             it can start at the very top of the column — behind the search bar — instead of
@@ -186,10 +188,20 @@ export function Layout({
               className="pointer-events-none absolute inset-x-0 top-0 h-[22rem] overflow-hidden [mask-image:linear-gradient(to_bottom,background_25%,transparent)] rounded-tl-lg"
               aria-hidden="true"
             >
-              <span className="absolute -inset-x-1/4 -top-1/2 bottom-0 scale-125 opacity-40 blur-[64px] saturate-[2]">
+              {/*
+                The blur radius drives the intermediate textures the compositor allocates, and
+                this is one of the largest surfaces in the window. 32px is enough here because
+                the source is a 120px image stretched across the full width — a ~20x upscale is
+                already most of the softness, and the filter only finishes the job.
+
+                `scale-125` is gone for the same reason: the negative insets already extend this
+                well past the clipped box on three sides, so the scale was adding composited
+                area to hide edges that were never reachable.
+              */}
+              <span className="absolute -inset-x-1/4 -top-1/2 bottom-0 opacity-40 blur-[32px] saturate-[2]">
                 {/*
-                  Deliberately the smallest variant: this is blurred by 64px and dropped to 40%
-                  opacity, so nothing above 120px survives to be seen — it only costs texture.
+                  Deliberately the smallest variant: this is blurred and dropped to 40% opacity,
+                  so nothing above 120px survives to be seen — it only costs texture.
                 */}
                 <TrackArtwork
                   className="size-full"
@@ -312,7 +324,7 @@ export function Layout({
                   animate={{ width: rightPanelWidth, opacity: 1 }}
                   exit={{ width: 0, opacity: 0 }}
                   transition={{ type: "spring", stiffness: 420, damping: 40 }}
-                  className="relative min-h-0 shrink-0 overflow-hidden  bg-card backdrop-blur"
+                  className="relative min-h-0 shrink-0 overflow-hidden bg-card"
                 >
                   {rightPanel}
                 </motion.div>

--- a/src/ui/components/PickCard.tsx
+++ b/src/ui/components/PickCard.tsx
@@ -6,6 +6,12 @@ import { TrackArtwork } from "./TrackArtwork";
 /** Movement past this many px means the gesture was a carousel drag, not a tap. */
 const TAP_SLOP_PX = 5;
 
+/**
+ * Resting card width — `PICKS_ITEM_SIZE` (250) × `PICKS_ASPECT` (3/4) in HomePage, rounded up
+ * for the centre card's scale-up. Only the size bucket it lands in matters.
+ */
+const CARD_WIDTH_PX = 200;
+
 interface PickCardProps {
   artworkUrl?: string;
   title: string;
@@ -121,6 +127,11 @@ export function PickCard({
           className="size-full transition-transform duration-200 ease-out group-hover/pick:scale-[1.04]"
           artworkUrl={artworkUrl}
           iconSize={44}
+          /*
+           * The carousel's own hover/centre scaling peaks a little above 1, so the slot is
+           * requested slightly larger than its resting width rather than at exactly it.
+           */
+          size={CARD_WIDTH_PX}
           variant="album"
         />
 

--- a/src/ui/components/SearchBar.tsx
+++ b/src/ui/components/SearchBar.tsx
@@ -54,7 +54,7 @@ export function SearchBar({
         type="button"
         onClick={onOpen}
         data-onboarding="search"
-        className="group flex h-9 min-w-0 flex-1 items-center gap-2.5 rounded-full bg-card px-3.5 text-left text-sm text-muted-foreground backdrop-blur transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        className="group flex h-9 min-w-0 flex-1 items-center gap-2.5 rounded-full bg-card px-3.5 text-left text-sm text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
       >
         <SearchIcon size={17} className="shrink-0" />
         <span className="truncate">Search artists, songs, playlists, and albums</span>

--- a/src/ui/components/Sidebar.tsx
+++ b/src/ui/components/Sidebar.tsx
@@ -1078,7 +1078,7 @@ export function Sidebar({
   return (
     <div
       ref={sidebarRef}
-      className="relative flex min-h-0 shrink-0 flex-col bg-background backdrop-blur transition-[width] duration-200 ease-out"
+      className="relative flex min-h-0 shrink-0 flex-col bg-background transition-[width] duration-200 ease-out"
       style={{ width: `${effectiveWidth}px` }}
       onPointerEnter={(event) => {
         // Pointer only. A drag passing over the rail is not a request to expand it, and a

--- a/src/ui/components/StarField.tsx
+++ b/src/ui/components/StarField.tsx
@@ -9,6 +9,11 @@
  * Kept deliberately low-contrast: this sits behind real UI, so it must never compete with
  * text or controls. Callers gate it on Paper-PC mode (see Layout.tsx), which is also why
  * this is plain CSS — no WebGL, no animation, nothing to disable.
+ *
+ * The blobs are blurred at `2xl` (40px) rather than `3xl` (64px). Both are always on screen,
+ * and blur radius is what sizes the compositor's intermediate textures — but the shapes here
+ * are already `rounded-full` gradients fading to transparent, so most of the softness comes
+ * from the fill rather than from the filter.
  */
 export function StarField() {
   return (
@@ -23,9 +28,9 @@ export function StarField() {
       */}
       <div className="absolute inset-0" style={{ opacity: "var(--ambient-bloom)" }}>
         {/* Primary bloom, offset left of centre. */}
-        <div className="absolute left-1/3 top-0 size-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full bg-linear-to-b from-orange-500/70 to-transparent blur-3xl" />
+        <div className="absolute left-1/3 top-0 size-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full bg-linear-to-b from-orange-500/70 to-transparent blur-2xl" />
         {/* Warmer, smaller companion bloom to the right. */}
-        <div className="absolute left-2/3 top-0 size-1/3 -translate-x-1/2 -translate-y-1/2 rounded-full bg-linear-to-b from-rose-400/25 to-transparent blur-3xl" />
+        <div className="absolute left-2/3 top-0 size-1/3 -translate-x-1/2 -translate-y-1/2 rounded-full bg-linear-to-b from-rose-400/25 to-transparent blur-2xl" />
       </div>
       {/* Vignette: transparent at the top, settling into the window background. */}
       <div

--- a/src/ui/components/TitleBar.tsx
+++ b/src/ui/components/TitleBar.tsx
@@ -137,7 +137,7 @@ export function TitleBar({
   };
 
   return (
-    <div className="relative z-30 flex h-[var(--titlebar-height)] shrink-0 items-stretch bg-background backdrop-blur ">
+    <div className="relative z-30 flex h-[var(--titlebar-height)] shrink-0 items-stretch bg-background">
       <button
         type="button"
         style={{ width: `${sidebarWidth}px` }}

--- a/src/ui/components/TrackRow.tsx
+++ b/src/ui/components/TrackRow.tsx
@@ -416,6 +416,20 @@ export const TrackRow = memo(function TrackRow({
         "group/row relative flex w-full items-center gap-3 rounded-xl px-2 py-1.5 text-left",
         "transition-colors hover:bg-card focus-visible:outline-none focus-visible:ring-2",
         "focus-visible:ring-inset focus-visible:ring-ring",
+        /*
+         * Off-screen rows skip layout, paint and compositing.
+         *
+         * These lists are not windowed — a 500-track playlist really does build 500 rows of
+         * ~20 elements each — and windowing them properly fights both the drag-reorder and the
+         * shift-range selection, which need the full index space. This is the platform doing
+         * the same job for one line: the nodes stay, the rendering work does not.
+         *
+         * `auto 52px` is the row's height (40px artwork + `py-1.5`); the `auto` keyword means
+         * the browser prefers the size it last actually measured, so the guess only matters for
+         * rows that have never been on screen. Width is untouched by the containment because
+         * `w-full` states it outright rather than deriving it from content.
+         */
+        "[content-visibility:auto] [contain-intrinsic-size:auto_52px]",
         isCurrent && "bg-primary/5",
         isSelected && "bg-primary/10",
         className,

--- a/src/ui/components/mini-player/MiniPlayer.tsx
+++ b/src/ui/components/mini-player/MiniPlayer.tsx
@@ -492,13 +492,23 @@ export default function MiniPlayer() {
 
   const handleRestore = async () => {
     await emit("mini-player:restore-main");
-    await win.hide();
+
+    /*
+     * Best-effort, and deliberately not awaited into the restore below.
+     *
+     * The main window answers that event by *destroying* this window rather than hiding it,
+     * so a hide issued here can land after the window is already gone and reject. Awaited,
+     * that rejection aborts the rest of this function and leaves the main window in the
+     * background — the click appears to do nothing. Kept only for the instant visual
+     * feedback while the destroy makes its way across.
+     */
+    void win.hide().catch(() => {});
+
     const mainWin = await WebviewWindow.getByLabel("main");
     if (mainWin) {
       await mainWin.show();
       await mainWin.unminimize();
       await mainWin.setFocus();
-      await win.hide();
     }
   };
 
@@ -607,8 +617,13 @@ export default function MiniPlayer() {
     void handleRestore();
   };
 
+  /*
+   * Destroys rather than hides. Dismissing the pill is a request for it to stop being there,
+   * and a hidden webview keeps its entire renderer process — the thing this window is created
+   * on demand to avoid. The main window creates a fresh one next time it is backgrounded.
+   */
   const handleClose = async () => {
-    await win.hide();
+    await win.destroy();
   };
 
   const stopManualWindowDrag = async () => {

--- a/src/ui/components/player/PlayerBar.tsx
+++ b/src/ui/components/player/PlayerBar.tsx
@@ -173,7 +173,7 @@ export function PlayerBar({ onToggleLyrics, onToggleQueue, isQueueOpen, onConnec
       </AnimatePresence>
 
       <div
-        className="group/playerbar flex shrink-0 flex-col gap-1 bg-background px-4 pb-3 pt-2 backdrop-blur"
+        className="group/playerbar flex shrink-0 flex-col gap-1 bg-background px-4 pb-3 pt-2"
         onClick={handlePlayerBarClick}
       >
         {/* Expanded: the seek bar spans the full bar above everything. */}

--- a/src/ui/components/player/QueuePanel.tsx
+++ b/src/ui/components/player/QueuePanel.tsx
@@ -549,7 +549,7 @@ export function QueuePanel({ onClose }: QueuePanelProps) {
     >
       <header
         className={cn(
-          "sticky top-0 z-10 flex shrink-0 items-center gap-1 bg-card backdrop-blur",
+          "sticky top-0 z-10 flex shrink-0 items-center gap-1 bg-card",
           collapsed ? "flex-col px-2 py-2" : "px-3 py-2.5",
         )}
       >

--- a/src/ui/pages/HomePage.tsx
+++ b/src/ui/pages/HomePage.tsx
@@ -52,6 +52,35 @@ const suggestionCache = new Map<string, Track[]>();
 const suggestionLoads = new Map<string, Promise<Track[]>>();
 const EMPTY_TRACKS: Track[] = [];
 
+/**
+ * Cap on memoized suggestion sets.
+ *
+ * The key carries both the tab and a signature of the recently-played list, so a new entry
+ * appears for every tab and again on every library refresh — and each holds 36 full tracks.
+ * Unbounded, that grew for as long as the app stayed open.
+ *
+ * Insertion order gives LRU for free: reads re-insert, so eviction takes the coldest.
+ */
+const MAX_SUGGESTION_ENTRIES = 20;
+
+function readSuggestionCache(key: string): Track[] | undefined {
+  const hit = suggestionCache.get(key);
+  if (hit === undefined) return undefined;
+  suggestionCache.delete(key);
+  suggestionCache.set(key, hit);
+  return hit;
+}
+
+function writeSuggestionCache(key: string, tracks: Track[]): void {
+  suggestionCache.delete(key);
+  suggestionCache.set(key, tracks);
+
+  for (const coldest of [...suggestionCache.keys()]) {
+    if (suggestionCache.size <= MAX_SUGGESTION_ENTRIES) break;
+    suggestionCache.delete(coldest);
+  }
+}
+
 interface HomePageProps {
   tabId: string;
   playerController: PlayerControllerActions;
@@ -86,19 +115,28 @@ export function HomePage({
 }: HomePageProps) {
   const { openTrackMenu } = useTrackContextMenu();
   const showMadeForYou = useMadeForYouVisible();
-  const [suggestions, setSuggestions] = useState<Track[]>(
-    () => suggestionCache.get(tabId) ?? [],
-  );
-  const [isLoadingSuggestions, setIsLoadingSuggestions] = useState(
-    () => !suggestionCache.has(tabId),
-  );
-  const [isSurpriseSpinning, setIsSurpriseSpinning] = useState(false);
-  const loadIdRef = useRef(0);
   const recentlyPlayed = useMemo(
     () => libraryState.library?.recentlyPlayed ?? EMPTY_TRACKS,
     [libraryState.library],
   );
   const recentTrackKey = recentlyPlayed.map((track) => track.id).join(":");
+  /*
+   * Computed before the state below, not after, so the initial render can read the cache under
+   * the key writes actually use. It previously seeded from `tabId` alone — a key nothing ever
+   * stored — so the memo never hit and Home opened on a spinner every single time, which is
+   * the exact thing this cache exists to prevent.
+   */
+  const suggestionCacheKey = recentlyPlayed.length > 0
+    ? `${tabId}:recent:${recentTrackKey}`
+    : `${tabId}:${libraryState.status}:empty`;
+  const [suggestions, setSuggestions] = useState<Track[]>(
+    () => readSuggestionCache(suggestionCacheKey) ?? [],
+  );
+  const [isLoadingSuggestions, setIsLoadingSuggestions] = useState(
+    () => !suggestionCache.has(suggestionCacheKey),
+  );
+  const [isSurpriseSpinning, setIsSurpriseSpinning] = useState(false);
+  const loadIdRef = useRef(0);
   /*
    * What is shown as "Recently played": this session's plays first, then YouTube's history.
    * The library snapshot only refreshes on start-up, so on its own the row sat unchanged
@@ -116,9 +154,6 @@ export function HomePage({
       || libraryState.status === "loading"
       || libraryState.status === "authorizing"
     );
-  const suggestionCacheKey = recentlyPlayed.length > 0
-    ? `${tabId}:recent:${recentTrackKey}`
-    : `${tabId}:${libraryState.status}:empty`;
 
   useEffect(() => {
     if (isWaitingForLibrary) {
@@ -128,7 +163,7 @@ export function HomePage({
       return;
     }
 
-    const cached = suggestionCache.get(suggestionCacheKey);
+    const cached = readSuggestionCache(suggestionCacheKey);
     if (cached) {
       setSuggestions(cached);
       setIsLoadingSuggestions(false);
@@ -168,7 +203,7 @@ export function HomePage({
     }
 
     void loadPromise.then((loadedSuggestions) => {
-      suggestionCache.set(suggestionCacheKey, loadedSuggestions);
+      writeSuggestionCache(suggestionCacheKey, loadedSuggestions);
       suggestionLoads.delete(suggestionCacheKey);
       if (loadId !== loadIdRef.current) return;
       setSuggestions(loadedSuggestions);

--- a/src/ui/pages/SettingsPage.tsx
+++ b/src/ui/pages/SettingsPage.tsx
@@ -132,6 +132,12 @@ import {
   type SidebarMode,
 } from "../settings/sidebarMode";
 import {
+  AUDIO_ENGINE_MODES,
+  setAudioEngineMode,
+  useAudioEngineMode,
+  type AudioEngineMode,
+} from "../settings/audioEngine";
+import {
   captureKeyboardShortcut,
   formatKeyboardShortcut,
   KEYBOARD_SHORTCUT_ACTIONS,
@@ -425,6 +431,7 @@ export function SettingsPage({
   const miniPlayerEnabled = useMiniPlayerEnabled();
   const miniPlayerHoverAction = useMiniPlayerHoverAction();
   const sidebarMode = useSidebarMode();
+  const audioEngineMode = useAudioEngineMode();
   const preferredLyricsSource = usePreferredLyricsSourceId();
   const lyricsFontScale = useLyricsFontScale();
   const lyricsTranslationLang = useLyricsTranslationLang();
@@ -1710,6 +1717,48 @@ export function SettingsPage({
 
       {activeTab === "playback" && (
         <div className="flex flex-col gap-5" role="tabpanel" aria-label="Playback settings">
+          <section className={SETTINGS_CARD} aria-labelledby="playback-engine-title">
+            <SettingsCardHeader
+              title="Audio engine"
+              titleId="playback-engine-title"
+              icon={<PlayIcon size={18} aria-hidden="true" />}
+              description="What actually plays the sound."
+            />
+
+            <SettingRow
+              title="Playback method"
+              description={
+                audioEngineMode === "native"
+                  ? "Zuno resolves and downloads each track itself, then plays it locally. No hidden YouTube frame, so the app uses roughly 90 MB less. Tracks take a moment longer to start, and gapless and crossfade below do not apply."
+                  : "A hidden YouTube player streams each track. Slightly heavier, but it starts faster and is the only engine that can do gapless and crossfade. Come back here if native playback fails to start a song."
+              }
+            >
+              {() => (
+                <Select
+                  className="w-52"
+                  value={audioEngineMode}
+                  onValueChange={(value) => setAudioEngineMode(value as AudioEngineMode)}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {AUDIO_ENGINE_MODES.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
+            </SettingRow>
+
+            <p className="px-1 text-xs text-muted-foreground">
+              Takes effect on the next track — whatever is playing now finishes on the engine
+              that started it, and only frees the hidden YouTube frame once it does.
+            </p>
+          </section>
+
           <section className={SETTINGS_CARD} aria-labelledby="playback-settings-title">
             <SettingsCardHeader
               title="Transitions"

--- a/src/ui/settings/audioEngine.ts
+++ b/src/ui/settings/audioEngine.ts
@@ -1,0 +1,115 @@
+import { useSyncExternalStore } from "react";
+import {
+  hydrateLocalJsonSetting,
+  readLocalJsonSetting,
+  writeLocalJsonSetting,
+} from "../../internal/durableLocalSetting";
+
+/**
+ * Which pipeline actually makes sound.
+ *
+ * `iframe` hands the video id to a hidden YouTube IFrame player and lets Google's own embed
+ * resolve and stream it. `native` resolves the signed URL here, downloads it through Rust, and
+ * plays the bytes from the local media server through an `<audio>` element.
+ *
+ * The difference that matters is a whole second webview: the IFrame player runs in a
+ * `youtube.com` subframe process of its own, which costs roughly 90 MB and a steady slice of
+ * the GPU process. Native has no subframe at all.
+ *
+ * Native is not the default *yet*, for three reasons: it resolves a signed URL and downloads
+ * the whole track before the first sample plays, so it starts slower; it is the path that
+ * historically answered 403, which is why this was hardcoded off until PO tokens landed; and
+ * gapless and crossfade ride the standby IFrame deck, so neither applies to it. Downloads have
+ * used this exact resolve-and-fetch path successfully since PO tokens, which is what makes it
+ * worth offering — leaving the default alone means a regression costs a setting rather than
+ * everyone's playback.
+ */
+export type AudioEngineMode = "iframe" | "native";
+
+const STORAGE_KEY = "audio-engine-mode";
+/** Exported so `AudioEngine` can free its decks the moment the mode stops being `iframe`. */
+export const AUDIO_ENGINE_MODE_CHANGE_EVENT = "audio-engine-mode-change";
+const CHANGE_EVENT = AUDIO_ENGINE_MODE_CHANGE_EVENT;
+const DEFAULT_MODE: AudioEngineMode = "iframe";
+
+export const AUDIO_ENGINE_MODES: ReadonlyArray<{
+  value: AudioEngineMode;
+  label: string;
+  hint: string;
+}> = [
+  {
+    value: "iframe",
+    label: "YouTube player",
+    hint: "Most reliable. Runs a hidden youtube.com frame, ~90 MB.",
+  },
+  {
+    value: "native",
+    label: "Native audio",
+    hint: "No hidden frame. Lower memory, slower to start, no gapless or crossfade.",
+  },
+];
+
+function isAudioEngineMode(value: unknown): value is AudioEngineMode {
+  return value === "iframe" || value === "native";
+}
+
+/*
+ * Cached because `AudioEngine` reads this on every load, play, pause, seek and volume change —
+ * a synchronous localStorage hit on each would sit directly in the playback path.
+ */
+let cachedMode: AudioEngineMode | null = null;
+
+function readMode(): AudioEngineMode {
+  if (cachedMode === null) {
+    cachedMode = readLocalJsonSetting(STORAGE_KEY, isAudioEngineMode) ?? DEFAULT_MODE;
+  }
+  return cachedMode;
+}
+
+function subscribe(callback: () => void) {
+  window.addEventListener(CHANGE_EVENT, callback);
+  window.addEventListener("storage", callback);
+
+  return () => {
+    window.removeEventListener(CHANGE_EVENT, callback);
+    window.removeEventListener("storage", callback);
+  };
+}
+
+/*
+ * The cache has to drop on a write from the other window too, or the mini player keeps
+ * answering with the value it read at startup.
+ *
+ * Guarded because this runs at import and `player/AudioEngine.ts` imports this module — which
+ * puts it one import away from the `*.check.ts` bundles, and those run in Node with no `window`.
+ */
+if (typeof window !== "undefined") {
+  window.addEventListener("storage", () => {
+    cachedMode = null;
+  });
+}
+
+export function getAudioEngineMode(): AudioEngineMode {
+  return readMode();
+}
+
+/** True when the current mode plays through `<audio>` rather than the YouTube IFrame. */
+export function usesNativeAudioEngine(): boolean {
+  return readMode() === "native";
+}
+
+export function setAudioEngineMode(mode: AudioEngineMode) {
+  cachedMode = mode;
+  writeLocalJsonSetting(STORAGE_KEY, mode);
+  window.dispatchEvent(new Event(CHANGE_EVENT));
+}
+
+export async function hydrateAudioEngineMode(): Promise<void> {
+  await hydrateLocalJsonSetting(STORAGE_KEY, isAudioEngineMode);
+  cachedMode = null;
+  window.dispatchEvent(new Event(CHANGE_EVENT));
+}
+
+export function useAudioEngineMode(): AudioEngineMode {
+  return useSyncExternalStore(subscribe, readMode, () => DEFAULT_MODE);
+}

--- a/src/ui/settings/miniPlayer.ts
+++ b/src/ui/settings/miniPlayer.ts
@@ -139,6 +139,23 @@ export async function hydrateMiniPlayerSettings() {
  */
 let miniPlayerCreation: Promise<WebviewWindow | null> | null = null;
 
+/*
+ * Creation and destruction are serialized against each other.
+ *
+ * Alt-tabbing fires blur and focus within a few milliseconds, and focus now *destroys* the
+ * window rather than hiding it. Interleaved, the pair can either leave an orphan on screen or
+ * tear down the window that was just asked for. One chain means the last call wins.
+ */
+let miniPlayerOps: Promise<unknown> = Promise.resolve();
+
+function queueMiniPlayerOp<T>(op: () => Promise<T>): Promise<T> {
+  const next = miniPlayerOps.then(op, op);
+  // A rejection belongs to its own caller; the chain has to survive it or every later
+  // show and hide is dropped with it.
+  miniPlayerOps = next.catch(() => undefined);
+  return next;
+}
+
 async function createMiniPlayerWindow(): Promise<WebviewWindow | null> {
   const existing = await WebviewWindow.getByLabel(MINI_PLAYER_LABEL);
   if (existing) return existing;
@@ -172,7 +189,7 @@ async function createMiniPlayerWindow(): Promise<WebviewWindow | null> {
 export function ensureMiniPlayerWindow(): Promise<WebviewWindow | null> {
   if (miniPlayerCreation) return miniPlayerCreation;
 
-  const creation = createMiniPlayerWindow();
+  const creation = queueMiniPlayerOp(createMiniPlayerWindow);
   miniPlayerCreation = creation;
   void creation.catch(() => null).finally(() => {
     if (miniPlayerCreation === creation) miniPlayerCreation = null;
@@ -181,14 +198,16 @@ export function ensureMiniPlayerWindow(): Promise<WebviewWindow | null> {
 }
 
 /** Frees the window's process. `hide()` keeps it resident; only destroying returns the memory. */
-export async function destroyMiniPlayerWindow() {
-  const miniWin = await WebviewWindow.getByLabel(MINI_PLAYER_LABEL);
-  if (!miniWin) return;
-  try {
-    await miniWin.destroy();
-  } catch {
-    // Already gone, or closing concurrently; either way there is nothing left to free.
-  }
+export function destroyMiniPlayerWindow(): Promise<void> {
+  return queueMiniPlayerOp(async () => {
+    const miniWin = await WebviewWindow.getByLabel(MINI_PLAYER_LABEL);
+    if (!miniWin) return;
+    try {
+      await miniWin.destroy();
+    } catch {
+      // Already gone, or closing concurrently; either way there is nothing left to free.
+    }
+  });
 }
 
 export async function resetMiniPlayerPosition() {


### PR DESCRIPTION
Memory work plus the landing page and packaging changes already on `dev`.

**Memory — WebView2 group 463 MB → ~380 MB, and now flat instead of climbing**

- Mini player window is created on first show and destroyed on focus, not hidden (~32 MB). Create/destroy serialized so an alt-tab blur/focus pair can't orphan it.
- New audio engine setting: `iframe` (default) or `native`. Native drops the hidden `youtube.com` subframe (~90 MB). Gapless/crossfade are iframe-only; the setting says so.
- Media server leak: capped at 3 entries, stable keys (a replay was storing a second copy), and `Cache-Control: no-store` so the renderer stops retaining every audio body.
- Removed 7 always-on `backdrop-blur` layers sitting behind fully opaque backgrounds — invisible, but each cost a composited layer and a blur pass.
- `content-visibility: auto` on `TrackRow`; artwork size buckets on `AlbumCard`/`PickCard`; artwork blob cap 32 → 16 MB.
- Session persist heartbeat 1s → 5s and skips unchanged writes. It was rebuilding and stringifying every tab's full queue every second.
- `suggestionCache` capped at 20 (was unbounded) and its key fixed — it read a key shape nothing ever wrote, so Home opened on a spinner every time.

**Also**

- rpm bundle alongside deb and AppImage
- Silent auth refresh fix
- Landing page: logo, OS badges, floating mini player
- `docs/architecture.md`, `backend.md`, `frontend.md` updated

2 new Rust tests (13 total), 20 `*.check.ts` pass, build clean.
