### PR TITLE
release: 1.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zuno",
   "private": true,
-  "version": "1.2.1",
+  "version": "1.2.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6294,7 +6294,7 @@ checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zuno"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zuno"
-version = "1.2.1"
+version = "1.2.2"
 description = "Zuno - a desktop music client"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Zuno",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "identifier": "com.zuno.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/internal/releaseNote.ts
+++ b/src/internal/releaseNote.ts
@@ -10,11 +10,13 @@ import { getAppSetting, setAppSetting } from "./appSettings";
  */
 const SEEN_VERSION_KEY = "release-note-seen-version";
 
-export const RELEASE_NOTE_BODY = `This is the last major update for a while, with a lot of new features and bug fixes. I'll be away for a bit, but I'll still ship patches for anything critical.
+export const RELEASE_NOTE_BODY = `Tracks start noticeably faster this time, and skipping ahead is close to instant.
 
-Come say hello at /r/myzuno, and report anything broken on GitHub.
+Settings now has a native audio engine you can switch to — it drops the hidden YouTube frame and about 90 MB with it. You can also let Zuno add plays to your YouTube Music history, and albums show in track lists with a link straight to them.
 
-Thank you, and enjoy :)`;
+Report anything broken on GitHub, or come say hello at /r/myzuno.
+
+Thanks :)`;
 
 export type ReleaseNoteSegment =
   | { kind: "text"; value: string }


### PR DESCRIPTION
Patch bump for everything merged since 1.2.1 (#27, #28, #29).

- `package.json`, `Cargo.toml`, `tauri.conf.json` and `Cargo.lock` in lockstep
- `RELEASE_NOTE_BODY` rewritten — it is keyed to the installed version, so this is what shows once after updating

Merging this lands a version change on main, which is what `release.yml` watches. 21 checks, 16 Rust tests.
