### PR TITLE
Rust audio engine, equaliser, 1.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,9 @@ jobs:
             libsoup-3.0-dev \
             librsvg2-dev \
             libssl-dev \
-            build-essential
+            build-essential \
+            libasound2-dev \
+            cmake
 
       # `--locked` because a Cargo.toml change that forgets its Cargo.lock is the other way this
       # goes wrong quietly.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,6 +194,8 @@ jobs:
             libgtk-3-dev \
             libsoup-3.0-dev \
             libjavascriptcoregtk-4.1-dev \
+            libasound2-dev \
+            cmake \
             patchelf
 
       - name: Cache Rust build

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -59,7 +59,11 @@ Four rules explain most of the design:
    CORS/cookie rules never apply, cookie auth can be signed properly, and rotated `Set-Cookie`
    values can be merged back into the stored session.
 2. **There are three playback engines and the user picks one** (`ui/settings/audioEngine.ts`).
-   `iframe` (the default) hands the video id to a hidden YouTube IFrame player, dodging the 403s
+   `rust` is the default: it resolves the signed URL, decodes it in the Rust process and plays
+   straight out to the sound card — no subframe, no media element, no audio in the renderer. A
+   resolve or fetch that Google refuses is **not fatal**: `ensureTrackLoaded` catches it and plays
+   that one track on the IFrame deck instead, which is what made defaulting to it safe.
+   `iframe` hands the video id to a hidden YouTube IFrame player, dodging the 403s
    that signed googlevideo URLs return when replayed from a different context — at the cost of a
    `youtube.com` subframe process, roughly 90 MB. `native` resolves and downloads the track through
    Rust and plays it from an `<audio>` element, with no subframe at all. `rust` resolves the same

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -488,8 +488,12 @@ Recorded so nobody re-derives them:
   broke, which is the proof it is inert.
 - Gapless and crossfade silently do nothing in `native` audio-engine mode — they ride the standby
   IFrame deck, which that mode has no equivalent of. The Settings copy says so, but nothing in the
-  code prevents the combination. **`rust` mode is the fix**: it has two real decks and mixes them,
-  so `usesPreloadDeck()` admits it alongside `iframe`. `native` is what is left over.
+  code prevents the combination. **`rust` mode is the fix**: it has two real decks and mixes
+  them, and unlike the IFrame pair they open whatever they are handed — a signed URL, a file in
+  the offline store, a path on disk — so a downloaded album is gapless too. `player/preloadDeck.ts`
+  holds the rule and `preloadDeck.check.ts` pins it: the IFrame deck must keep excluding anything
+  read from disk, because it resolves its own stream from a video id and would fetch the online
+  copy of a track the user downloaded on purpose.
 - Playback rate on the `rust` engine resamples, so it transposes — the `<audio>` element corrected
   pitch for free via `preservesPitch`. Marked `ponytail:` at `native_audio_set_rate`; the fix is a
   time-stretcher between the decoder and the sink.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -494,9 +494,11 @@ Recorded so nobody re-derives them:
   pitch for free via `preservesPitch`. Marked `ponytail:` at `native_audio_set_rate`; the fix is a
   time-stretcher between the decoder and the sink.
 - `MediaServer` — the loopback `TcpListener`, `MEDIA_SERVER_MAX_ITEMS`, `Cache-Control: no-store`
-  and `parse_media_range` — exists only to hand bytes to an `<audio>` element. Once `rust` is the
-  default and the other two engines go, all of it and `fetch_audio_source` go with them.
-  `MediaBuffer` stays: the Rust decoder reads through it.
+  and `parse_media_range` — exists only to hand bytes to an `<audio>` element. In `rust` mode it is
+  never started from cold and `media_server_release` drops its bodies when switched into
+  mid-session, so what remains resident is one thread parked in `accept()`. Deleting the rest waits
+  on `rust` becoming the only engine; `fetch_audio_source` goes with it. `MediaBuffer` stays — the
+  Rust decoder reads through it.
 - `app.security.csp` can only be tightened once the IFrame path is gone; the `rust` engine loads
   nothing from `youtube.com` at runtime, so it is the precondition rather than the change.
 - `App.tsx` is 2156 lines with ~30 `useEffect` blocks, some at zero indentation — still the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -39,7 +39,7 @@ flowchart TB
     RPC["Discord IPC"]
     LFM["Last.fm API"]
     SRV["127.0.0.1 media server"]
-    SND["symphonia decode + cpal output<br/>two decks"]
+    SND["symphonia demux + libopus/rodio decode<br/>cpal output, two decks"]
     WATCH["notify folder watcher"]
   end
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,7 +20,7 @@ flowchart TB
     UI["React UI<br/>src/ui/**"]
     STATE["Controllers + stores<br/>src/player/**"]
     DS["DataSource layer<br/>src/datasource/**"]
-    IFRAME["Two hidden IFrame decks<br/><i>or</i> an &lt;audio&gt; element"]
+    IFRAME["Two hidden IFrame decks<br/><i>or</i> an &lt;audio&gt; element<br/><i>or</i> nothing — Rust plays it"]
   end
 
   subgraph Mini["mini-player window (mini.html → src/mini.tsx)"]
@@ -39,6 +39,7 @@ flowchart TB
     RPC["Discord IPC"]
     LFM["Last.fm API"]
     SRV["127.0.0.1 media server"]
+    SND["symphonia decode + cpal output<br/>two decks"]
     WATCH["notify folder watcher"]
   end
 
@@ -47,7 +48,7 @@ flowchart TB
   DS -->|invoke| CMD
   UI -->|invoke| CMD
   MP <-->|Tauri events| UI
-  CMD --> CACHE & OFF & SET & KEY & HTTP & MEDIA & TRAY & RPC & LFM & SRV & WATCH
+  CMD --> CACHE & OFF & SET & KEY & HTTP & MEDIA & TRAY & RPC & LFM & SRV & SND & WATCH
   HTTP -->|HTTPS| YT["music.youtube.com / googlevideo.com"]
   IFRAME -->|audio| YT
 ```
@@ -57,12 +58,14 @@ Four rules explain most of the design:
 1. **All network traffic to Google goes through Rust** (`proxy_http_request`) so the WebView's
    CORS/cookie rules never apply, cookie auth can be signed properly, and rotated `Set-Cookie`
    values can be merged back into the stored session.
-2. **There are two playback engines and the user picks one** (`ui/settings/audioEngine.ts`).
+2. **There are three playback engines and the user picks one** (`ui/settings/audioEngine.ts`).
    `iframe` (the default) hands the video id to a hidden YouTube IFrame player, dodging the 403s
    that signed googlevideo URLs return when replayed from a different context — at the cost of a
    `youtube.com` subframe process, roughly 90 MB. `native` resolves and downloads the track through
-   Rust and plays it from an `<audio>` element, with no subframe at all. Local and downloaded
-   tracks always take the native path regardless of the setting.
+   Rust and plays it from an `<audio>` element, with no subframe at all. `rust` resolves the same
+   URL and decodes it in the Rust process with symphonia, out to the sound card through cpal — no
+   subframe, no media element, and no audio in the renderer at all. Local and downloaded tracks
+   always take a non-IFrame path regardless of the setting.
 3. **Downloads are a separate path from playback.** `offline_audio_save` fetches the same signed URL
    in Rust with a PO token, in 4 MiB ranges, and stores the bytes on disk; playback of a downloaded
    track then never touches the network.
@@ -96,6 +99,8 @@ real `http://` origin. Dev builds use the normal Vite dev server on port 1420.
 | `window-focused` | main window regains focus | `App.tsx` — destroys the mini player window, triggers connection recovery |
 | `windows-media-control` | SMTC or taskbar thumbnail button pressed | `useMediaSession` |
 | `offline-download-progress` | per-chunk progress during `offline_audio_save` | `player/offlineStore.ts` |
+| `native-audio-position` | every 250 ms while the Rust engine is playing | `player/rustAudio.ts` — the cached playhead |
+| `native-audio-ended` | the Rust engine's active deck ran out of samples | `player/rustAudio.ts` → the playback-owning `AudioEngine` |
 | `local-audio-changed` | `notify` watcher sees a change under a watched music folder | `main.tsx` → `notifyLocalPlaylistsChanged()` |
 
 **Mini ↔ main** is a set of plain Tauri events, no shared controllers:
@@ -183,7 +188,8 @@ Cache keys are versioned strings (`youtube-music:library:v5`, `youtube-music:tra
 
 | Module | Responsibility |
 |---|---|
-| `AudioEngine.ts` | Owns **two** hidden YouTube IFrame decks plus an optional `HTMLAudioElement`, and routes between them on `shouldUseNativeAudio()` — a live read of the audio-engine setting, so a change takes effect on the next track rather than the next launch. The standby deck holds the *next* track already cued, which is what makes transitions gapless; with a non-zero crossfade the two decks' volumes are ramped past each other. **Neither applies in native mode**, which has no deck to preload onto. `releaseIframePlayer()` frees the decks (and their subframe process) without disposing the engine; a module-level listener calls it on every engine except the current playback owner when the setting flips to native. `playbackClaimId` + `playbackOwner` guarantee only one engine makes sound at a time. |
+| `AudioEngine.ts` | Owns **two** hidden YouTube IFrame decks, an optional `HTMLAudioElement`, and — in `rust` mode — a handle to the Rust engine's own pair of decks (`rustAudio.ts`), routing between them on the audio-engine setting. On the Rust path every method below delegates and this class holds only bookkeeping: which track is on which deck, so `hasPreloaded` stays synchronous. Routes between the first two on `shouldUseNativeAudio()` — a live read of the audio-engine setting, so a change takes effect on the next track rather than the next launch. The standby deck holds the *next* track already cued, which is what makes transitions gapless; with a non-zero crossfade the two decks' volumes are ramped past each other. **Neither applies in native mode**, which has no deck to preload onto. `releaseIframePlayer()` frees the decks (and their subframe process) without disposing the engine; a module-level listener calls it on every engine except the current playback owner when the setting flips to native. `playbackClaimId` + `playbackOwner` guarantee only one engine makes sound at a time. |
+| `rustAudio.ts` | The frontend half of the Rust engine: the `native_audio_*` invokes, plus the cached position that lets `getCurrentTime()` stay synchronous. Position is pushed from Rust on a 250 ms `native-audio-position` event rather than polled, because a progress frame cannot await an `invoke`. The `native-audio-ended` subscription is **process-wide and dispatched to the playback owner** — one per engine would have every open tab advance its own queue on the same track end. |
 | `Queue.ts` | Pure queue data structure with three regions: played/current, a **manual queue** segment (`playNext` / `addToQueue`), and automatic upcoming tracks. Shuffle only touches the automatic region and remembers the original order so it can be restored. `move()` rejects cross-region moves. |
 | `PlayerController.ts` | One per tab. Orchestrates DataSource → AudioEngine → Queue, playback order (shuffle and repeat compose independently), crossfade/gapless settings, playback rate, stop-after-track, radio/autoplay refills, history, error surfacing, session export/restore, and Discord presence updates. Warms the next track as soon as the current one starts — its metadata always, its audio too on the native engine — because a skip lands whenever the listener decides, not only in the last few seconds. |
 | `TabManager.ts` | Owns the `Map<tabId, PlayerController>`. Distinguishes the **focused** tab (what you're looking at) from the **playback owner** (what's making sound), and suspends/resumes engines on switch. |
@@ -304,6 +310,8 @@ letting a stale response overwrite state.
 |---|---|
 | YouTube, streaming, `iframe` mode | No stream URL is fetched at all — the IFrame deck handles it from the video id. |
 | YouTube, streaming, `native` mode | `getStreamData` → `resolveStreamUrl` → `fetch_audio_source` downloads it in parallel ranges and re-serves it from the local media server. The MP4 `ftyp` check only applies when MP4 was the format asked for — `high` now reaches Opus, which has no `ftyp` box. |
+| YouTube, streaming, `rust` mode | `getRustStreamData` → `resolveStreamUrl` → the signed URL and cookie go straight to `native_audio_load`. Rust publishes an empty `MediaBuffer` sized from the URL's own `clen`, starts the same ranged fill, and hands symphonia a reader over it — so what a click waits for is the 128 KiB head chunk, not the file. Nothing is published to the media server and no audio crosses IPC. |
+| Local / downloaded, `rust` mode | `getRustStreamData` returns a path or a track id. No base64, no media server — Rust opens the file. |
 | YouTube, downloaded | `offline_audio_source` serves the stored bytes from the media server, with Range support. No network. |
 | YouTube, download | `getStreamData` → Innertube `getBasicInfo` → best adaptive `audio/mp4` at the configured quality → decipher → PO token → `offline_audio_save` fetches it in 4 MiB ranges, 6 at a time, emitting progress. |
 | Local file | `local_audio_read` returns base64 bytes + a MIME type guessed from the extension; the frontend builds a `Blob` object URL. |
@@ -480,7 +488,17 @@ Recorded so nobody re-derives them:
   broke, which is the proof it is inert.
 - Gapless and crossfade silently do nothing in `native` audio-engine mode — they ride the standby
   IFrame deck, which that mode has no equivalent of. The Settings copy says so, but nothing in the
-  code prevents the combination.
+  code prevents the combination. **`rust` mode is the fix**: it has two real decks and mixes them,
+  so `usesPreloadDeck()` admits it alongside `iframe`. `native` is what is left over.
+- Playback rate on the `rust` engine resamples, so it transposes — the `<audio>` element corrected
+  pitch for free via `preservesPitch`. Marked `ponytail:` at `native_audio_set_rate`; the fix is a
+  time-stretcher between the decoder and the sink.
+- `MediaServer` — the loopback `TcpListener`, `MEDIA_SERVER_MAX_ITEMS`, `Cache-Control: no-store`
+  and `parse_media_range` — exists only to hand bytes to an `<audio>` element. Once `rust` is the
+  default and the other two engines go, all of it and `fetch_audio_source` go with them.
+  `MediaBuffer` stays: the Rust decoder reads through it.
+- `app.security.csp` can only be tightened once the IFrame path is gone; the `rust` engine loads
+  nothing from `youtube.com` at runtime, so it is the precondition rather than the change.
 - `App.tsx` is 2156 lines with ~30 `useEffect` blocks, some at zero indentation — still the
   highest-value refactor target in the repo.
 - `getStreamUrl` on the YouTube Music data source is required by the abstract class but never called

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -231,7 +231,11 @@ always use `offline_audio_save` below.
 
 `NativeAudioSource` is one of `stream` (a signed googlevideo URL), `offline` (a track id) or
 `file` (a path, re-validated here rather than trusted from the frontend). Each carries a mime
-type, because that is what picks the decoder — a downloaded body has no extension to read it from.
+type, because that is what picks the decoder — but for anything already on disk the *bytes* win:
+`sniff_container_mime` reads the first 64 and rewinds. `Track.mimeType` describes what was
+resolved for streaming and a row from a playlist listing has none at all, so a downloaded Opus
+file arrived declared `audio/mp4` and went to rodio, which parsed the Matroska and then had no
+Opus decoder for what was inside.
 
 **Opus is not optional.** symphonia has no Opus decoder in 0.5 — not a feature flag, the codec is
 absent — and YouTube serves `audio/webm; codecs="opus"` for the large majority of tracks at

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -225,9 +225,19 @@ always use `offline_audio_save` below.
 | `native_audio_transition` | `(track_id, fade_ms) -> bool` | Swaps to the standby deck. `fade_ms` of 0 is the gapless case; above 0 both decks play and their volumes ramp past each other. False means nothing was preloaded |
 | `native_audio_has_standby` | `(track_id) -> bool` | |
 | `native_audio_drop_standby` | `()` | |
+| `media_server_release` | `() -> usize` | Drops every body the media server holds, and returns how many. Called once on the first Rust load, after the `<audio>` element is torn down |
 
 `NativeAudioSource` is one of `stream` (a signed googlevideo URL), `offline` (a track id) or
 `file` (a path, re-validated here rather than trusted from the frontend).
+
+**The media server is not needed on this path at all.** `media_server()` is lazy, so an app that
+launches straight into `rust` mode never binds the listener — `fetch_audio_source` and
+`offline_audio_source` are the only callers and neither runs. Switching *into* `rust` mid-session
+is the case that matters, and `media_server_release` handles it: up to `MEDIA_SERVER_MAX_ITEMS`
+whole songs are dropped at the first Rust load, once the `<audio>` element that could still be
+range-requesting them is gone. The listener thread and its port stay — reclaiming those means the
+`OnceLock` has to become something emptiable *and* restartable, because the other two engines
+still need the server.
 
 Three things are load-bearing:
 

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -13,6 +13,7 @@ See [architecture.md](./architecture.md) for the system view.
 | `lib.rs` | ~3940 | Everything else: commands, cache, settings, logging, session storage + cookie jar, HTTP proxy, audio fetch, offline store, local files/tags/watcher, media server, tray, window events, builder wiring |
 | `audio.rs` | ~460 | The native engine: two rodio decks, the crossfade ramp, the position tick, and the blocking reader that lets symphonia decode a body still downloading |
 | `opus_source.rs` | ~250 | Opus playback — symphonia demuxes the WebM/Ogg container, libopus decodes the packets, the result is a rodio `Source` |
+| `equalizer.rs` | ~300 | Ten-band graphic EQ: a cascade of peaking biquads between the decoder and the deck |
 | `discord_rpc.rs` | 213 | Discord IPC client lifecycle and activity payloads |
 | `lastfm.rs` | 283 | Last.fm auth + scrobbling |
 | `windows_media.rs` | 630 | SMTC + taskbar thumbnail toolbar (Windows only) |
@@ -227,6 +228,7 @@ always use `offline_audio_save` below.
 | `native_audio_transition` | `(track_id, fade_ms) -> bool` | Swaps to the standby deck. `fade_ms` of 0 is the gapless case; above 0 both decks play and their volumes ramp past each other. False means nothing was preloaded |
 | `native_audio_has_standby` | `(track_id) -> bool` | |
 | `native_audio_drop_standby` | `()` | |
+| `native_audio_set_equalizer` | `(preamp_db, bands_db: Vec<f32>)` | Ten gains in dB, applied to whatever is playing |
 | `media_server_release` | `() -> usize` | Drops every body the media server holds, and returns how many. Called once on the first Rust load, after the `<audio>` element is torn down |
 
 `NativeAudioSource` is one of `stream` (a signed googlevideo URL), `offline` (a track id) or
@@ -251,6 +253,27 @@ are reconstructed against samples from somewhere else and arrive as noise.
 links **ALSA** on Linux (`libasound2-dev` / `alsa-lib`). Both are in `ci.yml`, `release.yml` and
 the AUR PKGBUILD. On Windows, cmake ships with the Visual Studio Build Tools but is not on `PATH`
 by default.
+
+### Equaliser (`equalizer.rs`)
+
+Peaking biquads at the ten ISO octave centres, direct form I, one filter chain per channel —
+sharing one across an interleaved stream would filter left against right. `EqualizedSource` wraps
+the decoder, so it applies to both decks and a crossfade stays consistent.
+
+- **Settings are process-global, not per-source.** A slider has to move the track *playing*, and
+  during a crossfade two decks have to agree. A source checks an `AtomicU64` generation per sample
+  and only takes the lock when it changed; locking per sample would put a mutex in the audio path.
+- **Direct form I** because its state is input/output history, which stays well behaved when the
+  coefficients change under it — and here they change mid-note whenever a slider moves.
+  `retune` swaps coefficients without touching that history, so there is no click.
+- **Flat is bypassed**, not run at unity.
+- **A limiter follows the bands** (`rodio::Source::limit`). Ten bands at +12 dB is far more than a
+  normalised track's headroom; without it the sum clips into something that sounds like a broken
+  decoder. Presets carry a negative preamp for the same reason.
+- Rust holds the values in memory only. `hydrateEqualizer` pushes the stored curve down at boot,
+  or the equaliser silently does nothing until a slider is touched.
+- **Only the Rust engine has it.** A track that fell back to the IFrame deck plays unequalised;
+  the settings section says so rather than leaving it to be discovered.
 
 **The media server is not needed on this path at all.** `media_server()` is lazy, so an app that
 launches straight into `rust` mode never binds the listener — `fetch_audio_source` and

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -11,6 +11,7 @@ See [architecture.md](./architecture.md) for the system view.
 |---|---|---|
 | `main.rs` | 24 | Windows AppUserModelID, WebView2 diagnostics workaround, calls `run()` |
 | `lib.rs` | ~3940 | Everything else: commands, cache, settings, logging, session storage + cookie jar, HTTP proxy, audio fetch, offline store, local files/tags/watcher, media server, tray, window events, builder wiring |
+| `audio.rs` | ~440 | The native engine: two rodio decks, the crossfade ramp, the position tick, and the blocking reader that lets symphonia decode a body still downloading |
 | `discord_rpc.rs` | 213 | Discord IPC client lifecycle and activity payloads |
 | `lastfm.rs` | 283 | Last.fm auth + scrobbling |
 | `windows_media.rs` | 630 | SMTC + taskbar thumbnail toolbar (Windows only) |
@@ -21,6 +22,7 @@ See [architecture.md](./architecture.md) for the system view.
 `tauri` (features `macos-private-api`, `tray-icon`, `image-png`),
 `tauri-plugin-{autostart,opener,localhost,updater,process,dialog}`,
 `reqwest` (rustls-tls, gzip/brotli/deflate, **stream**), `futures-util` (parallel range downloads),
+`rodio` 0.22 with `symphonia-all` (symphonia decodes, cpal plays, rodio resamples between them),
 `keyring` 3.6 with native backends, `lofty` 0.24 (audio tag read/write), `notify` 8.2 (folder
 watching), `discord-rich-presence`, `md5`, `base64`, `url`, `portpicker`.
 macOS adds `aes-gcm`, `objc2`, `objc2-foundation`, `block2`, `rand`. Windows adds the `windows`
@@ -207,8 +209,41 @@ Replacing a key mid-playback is safe: `handle_media_request` clones the `Arc` be
 a request already in flight finishes against the bytes it started with.
 
 **Note:** which of these runs for ordinary streaming depends on the audio-engine setting. In
-`iframe` mode (the default) none of them do — the IFrame decks stream directly. Downloads always
-use `offline_audio_save` below.
+`iframe` mode (the default) none of them do — the IFrame decks stream directly. In `rust` mode the
+media server is bypassed too: `native_audio_load` reads through `MediaBuffer` in-process. Downloads
+always use `offline_audio_save` below.
+
+### Audio — the native engine (`audio.rs`)
+
+| Command | Signature | Notes |
+|---|---|---|
+| `native_audio_load` | `(track_id, source, duration_sec?, standby?) -> f64` | Decodes onto the active deck, or the standby one when `standby`. Returns the duration decoded, falling back to the provider's when the container declares none — Opus in WebM usually does not |
+| `native_audio_play` / `_pause` / `_stop` | `()` | |
+| `native_audio_seek` | `(position_sec)` | |
+| `native_audio_set_volume` | `(volume, muted)` | |
+| `native_audio_set_rate` | `(rate)` | Resamples, so it transposes. See §7 |
+| `native_audio_transition` | `(track_id, fade_ms) -> bool` | Swaps to the standby deck. `fade_ms` of 0 is the gapless case; above 0 both decks play and their volumes ramp past each other. False means nothing was preloaded |
+| `native_audio_has_standby` | `(track_id) -> bool` | |
+| `native_audio_drop_standby` | `()` | |
+
+`NativeAudioSource` is one of `stream` (a signed googlevideo URL), `offline` (a track id) or
+`file` (a path, re-validated here rather than trusted from the frontend).
+
+Three things are load-bearing:
+
+- **One owned thread behind a channel.** cpal's stream handle is not `Send` on every backend and
+  Tauri state must be, so only the `Sender` escapes the module. The same thread runs the 250 ms
+  position tick out of its own `recv_timeout`, and steps an in-progress crossfade at 20 ms — a
+  fade that slept in the command loop would starve position events for its whole window.
+- **The decoder is built off the audio thread.** `rodio::Decoder::new` reads the container header,
+  which for a stream means waiting on the network; `native_audio_load` does it on a blocking pool
+  thread and sends the thread a ready `Box<dyn Source + Send>`. Preloading the next track therefore
+  never stalls the position feed of the one playing.
+- **`BufferReader` blocks rather than reporting a short read.** `MediaBuffer` only exposes its
+  contiguous prefix, so a read either returns bytes from offset 0 without a hole or waits for the
+  gap to fill. A short read would look like the end of the stream to symphonia. A failed download
+  reports EOF, not an error, so the track ends and the queue advances instead of hanging on a deck
+  that will never empty.
 
 **`fetch_audio_ranged`** is the one downloader both playback and the offline store use, so the
 two cannot drift apart on speed — playback used to take the single-request path while downloads
@@ -273,6 +308,7 @@ produce the same user-visible outcome — a rescan.
 | `update_windows_media_session` | `windows_media.rs` | Windows only (`#[cfg]` inside `generate_handler!`) |
 | `update_macos_media_session` | `macos_media.rs` | macOS only |
 | `quit_app` | `lib.rs` | Routes to `close_or_hide_main_window` |
+| `native_audio_*` | `audio.rs` | See §3. Emits `native-audio-position` and `native-audio-ended` |
 | `greet` | `lib.rs` | Tauri scaffolding leftover; unused |
 
 **Windows media** (`windows_media.rs`): a `MediaPlayer` + `SystemMediaTransportControls` pair driving
@@ -308,7 +344,8 @@ that the list is missing every command added since it was written (all `offline_
 blocks or stop treating them as a checklist; do not add to them expecting an effect.
 
 `app.security.csp` is `null` — no CSP. Required because the YouTube IFrame API script is loaded from
-`youtube.com` at runtime. If native playback ever replaces the IFrame path, this should be tightened.
+`youtube.com` at runtime. The `rust` audio engine loads nothing from `youtube.com`, so retiring the
+IFrame path is the precondition for tightening this.
 
 Defense in depth that *is* in place:
 
@@ -359,6 +396,7 @@ release workflow under `.github/workflows/`.
 | `cookie_domain_matches_*` | exact, parent-domain, and rejection cases |
 | `media_items_stay_capped_and_evict_the_coldest_first` | `store_media_item` holds the cap and drops the oldest, not an arbitrary entry |
 | `restoring_the_same_track_replaces_rather_than_accumulates` | a stable key means a replay reuses its slot |
+| `buffer_reader_serves_only_the_contiguous_prefix` | `BufferReader` waits for the head instead of serving a chunk that landed early, spans chunk boundaries in one read, reports EOF on a failed download, and clamps a seek past the end |
 
 The frontend's equivalent is `npm run check` (`scripts/run-checks.mjs` over `src/**/*.check.ts`).
 There is no component/DOM test harness on either side.

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -11,7 +11,8 @@ See [architecture.md](./architecture.md) for the system view.
 |---|---|---|
 | `main.rs` | 24 | Windows AppUserModelID, WebView2 diagnostics workaround, calls `run()` |
 | `lib.rs` | ~3940 | Everything else: commands, cache, settings, logging, session storage + cookie jar, HTTP proxy, audio fetch, offline store, local files/tags/watcher, media server, tray, window events, builder wiring |
-| `audio.rs` | ~440 | The native engine: two rodio decks, the crossfade ramp, the position tick, and the blocking reader that lets symphonia decode a body still downloading |
+| `audio.rs` | ~460 | The native engine: two rodio decks, the crossfade ramp, the position tick, and the blocking reader that lets symphonia decode a body still downloading |
+| `opus_source.rs` | ~250 | Opus playback — symphonia demuxes the WebM/Ogg container, libopus decodes the packets, the result is a rodio `Source` |
 | `discord_rpc.rs` | 213 | Discord IPC client lifecycle and activity payloads |
 | `lastfm.rs` | 283 | Last.fm auth + scrobbling |
 | `windows_media.rs` | 630 | SMTC + taskbar thumbnail toolbar (Windows only) |
@@ -23,6 +24,7 @@ See [architecture.md](./architecture.md) for the system view.
 `tauri-plugin-{autostart,opener,localhost,updater,process,dialog}`,
 `reqwest` (rustls-tls, gzip/brotli/deflate, **stream**), `futures-util` (parallel range downloads),
 `rodio` 0.22 with `symphonia-all` (symphonia decodes, cpal plays, rodio resamples between them),
+`symphonia` 0.5 directly for demuxing and `opus` 0.3 for the one codec symphonia lacks,
 `keyring` 3.6 with native backends, `lofty` 0.24 (audio tag read/write), `notify` 8.2 (folder
 watching), `discord-rich-presence`, `md5`, `base64`, `url`, `portpicker`.
 macOS adds `aes-gcm`, `objc2`, `objc2-foundation`, `block2`, `rand`. Windows adds the `windows`
@@ -228,7 +230,23 @@ always use `offline_audio_save` below.
 | `media_server_release` | `() -> usize` | Drops every body the media server holds, and returns how many. Called once on the first Rust load, after the `<audio>` element is torn down |
 
 `NativeAudioSource` is one of `stream` (a signed googlevideo URL), `offline` (a track id) or
-`file` (a path, re-validated here rather than trusted from the frontend).
+`file` (a path, re-validated here rather than trusted from the frontend). Each carries a mime
+type, because that is what picks the decoder — a downloaded body has no extension to read it from.
+
+**Opus is not optional.** symphonia has no Opus decoder in 0.5 — not a feature flag, the codec is
+absent — and YouTube serves `audio/webm; codecs="opus"` for the large majority of tracks at
+`high` quality, and as the *only* audio offered for many of them. So `opus_source.rs` uses
+symphonia purely as a demuxer and hands the packets to libopus; everything else (AAC, FLAC, MP3,
+ALAC, Vorbis, WAV) stays on `rodio::Decoder`. `is_opus()` routes on the declared mime type, and
+getting it wrong is a failed load rather than a fallback — neither decoder can read the other's
+format. Two details are load-bearing: OpusHead's **pre-skip** is discarded, or every track opens
+with an audible tick, and a **seek resets the decoder state**, or the first frames after a jump
+are reconstructed against samples from somewhere else and arrive as noise.
+
+**Build requirements this adds.** `opus` builds libopus from source with **cmake**, and `cpal`
+links **ALSA** on Linux (`libasound2-dev` / `alsa-lib`). Both are in `ci.yml`, `release.yml` and
+the AUR PKGBUILD. On Windows, cmake ships with the Visual Studio Build Tools but is not on `PATH`
+by default.
 
 **The media server is not needed on this path at all.** `media_server()` is lazy, so an app that
 launches straight into `rust` mode never binds the listener — `fetch_audio_source` and

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zuno",
   "private": true,
-  "version": "1.2.2",
+  "version": "1.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packaging/aur/zuno/PKGBUILD
+++ b/packaging/aur/zuno/PKGBUILD
@@ -27,6 +27,13 @@ depends+=(
   'gst-libav'
 )
 
+# The Rust audio engine bypasses WebKitGTK entirely: cpal opens ALSA directly, and libopus is
+# statically linked in rather than loaded, so only the ALSA runtime is needed here. The
+# GStreamer plugins above stay because the IFrame engine is still the default.
+depends+=(
+  'alsa-lib'
+)
+
 optdepends=(
   'gst-plugins-bad: extra container and codec support'
   'gst-plugins-ugly: extra codec support'

--- a/src-tauri/.cargo/config.toml
+++ b/src-tauri/.cargo/config.toml
@@ -1,0 +1,13 @@
+# libopus ships a CMakeLists that declares `cmake_minimum_required` below 3.5, and CMake 4
+# removed the compatibility shim for that — so a machine with a current CMake cannot configure
+# it at all:
+#
+#   CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
+#     Compatibility with CMake < 3.5 has been removed from CMake.
+#
+# This is CMake's own documented escape hatch, and it is set here rather than in the workflows
+# because it is not a CI quirk: anyone with CMake 4 hits it, and a contributor should not have to
+# discover the flag from a build-script panic. Remove it when `audiopus_sys` updates the bundled
+# libopus, or when the crate stops vendoring one.
+[env]
+CMAKE_POLICY_VERSION_MINIMUM = "3.5"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -68,6 +68,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "alsa"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812947049edcd670a82cd5c73c3661d2e58468577ba8489de58e1a73c04cbd5d"
+dependencies = [
+ "alsa-sys",
+ "bitflags 2.11.1",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "alsa-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad7569085a265dd3f607ebecce7458eaab2132a84393534c95b18dcbc3f31e04"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -90,6 +112,12 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 dependencies = [
  "derive_arbitrary",
 ]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "ascii"
@@ -675,6 +703,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "coreaudio-rs"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5d7dca3ebcf65a035582c9ad4385371a9d9ee6537474d2a278f4e1e475bb58"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
+ "objc2-audio-toolbox",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "cpal"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8942da362c0f0d895d7cac616263f2f9424edc5687364dfd1d25ef7eba506d7"
+dependencies = [
+ "alsa",
+ "coreaudio-rs",
+ "dasp_sample",
+ "jni 0.21.1",
+ "js-sys",
+ "libc",
+ "mach2",
+ "ndk",
+ "ndk-context",
+ "num-derive",
+ "num-traits",
+ "objc2",
+ "objc2-audio-toolbox",
+ "objc2-avf-audio",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -808,6 +880,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "dasp_sample"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
 name = "data-encoding"
@@ -1075,6 +1153,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "endi"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1148,6 +1235,12 @@ dependencies = [
  "event-listener",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "extended"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af9673d8203fcb076b19dfd17e38b3d4ae9f44959416ea532ce72415a6020365"
 
 [[package]]
 name = "fastrand"
@@ -2246,6 +2339,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2369,6 +2468,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "mach2"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a1b95cd5421ec55b445b5ae102f5ea0e768de1f82bd3001e11f426c269c3aea"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "markup5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2481,6 +2589,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
 name = "ndk-sys"
 version = "0.6.0+11769913"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2523,10 +2637,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -2583,6 +2738,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-audio-toolbox"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6948501a91121d6399b79abaa33a8aa4ea7857fe019f341b8c23ad6e81b79b08"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
+ "objc2",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-avf-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13a380031deed8e99db00065c45937da434ca987c034e13b87e4441f9e4090be"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-cloud-kit"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2591,6 +2771,29 @@ dependencies = [
  "bitflags 2.11.1",
  "objc2",
  "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1eebcea8b0dbff5f7c8504f3107c68fc061a3eb44932051c8cf8a68d969c3b2"
+dependencies = [
+ "dispatch2",
+ "objc2",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-audio-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a89f2ec274a0cf4a32642b2991e8b351a404d290da87bb6a9a9d8632490bd1c"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
 ]
 
 [[package]]
@@ -2610,7 +2813,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.11.1",
+ "block2",
  "dispatch2",
+ "libc",
  "objc2",
 ]
 
@@ -3228,7 +3433,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3510,6 +3715,19 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rodio"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a536bb79db59098ef71a4dd4246c02eb87b316deceb1b68e0cde7167ec01eb"
+dependencies = [
+ "cpal",
+ "dasp_sample",
+ "num-rational",
+ "symphonia",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4112,6 +4330,201 @@ dependencies = [
  "base64 0.21.7",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "symphonia"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5773a4c030a19d9bfaa090f49746ff35c75dfddfa700df7a5939d5e076a57039"
+dependencies = [
+ "lazy_static",
+ "symphonia-bundle-flac",
+ "symphonia-bundle-mp3",
+ "symphonia-codec-aac",
+ "symphonia-codec-adpcm",
+ "symphonia-codec-alac",
+ "symphonia-codec-pcm",
+ "symphonia-codec-vorbis",
+ "symphonia-core",
+ "symphonia-format-caf",
+ "symphonia-format-isomp4",
+ "symphonia-format-mkv",
+ "symphonia-format-ogg",
+ "symphonia-format-riff",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-bundle-flac"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91565e180aea25d9b80a910c546802526ffd0072d0b8974e3ebe59b686c9976"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-bundle-mp3"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4872dd6bb56bf5eac799e3e957aa1981086c3e613b27e0ac23b176054f7c57ed"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-codec-aac"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c263845aa86881416849c1729a54c7f55164f8b96111dba59de46849e73a790"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-adpcm"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dddc50e2bbea4cfe027441eece77c46b9f319748605ab8f3443350129ddd07f"
+dependencies = [
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-alac"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8413fa754942ac16a73634c9dfd1500ed5c61430956b33728567f667fdd393ab"
+dependencies = [
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-pcm"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e89d716c01541ad3ebe7c91ce4c8d38a7cf266a3f7b2f090b108fb0cb031d95"
+dependencies = [
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-vorbis"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f025837c309cd69ffef572750b4a2257b59552c5399a5e49707cc5b1b85d1c73"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-core"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea00cc4f79b7f6bb7ff87eddc065a1066f3a43fe1875979056672c9ef948c2af"
+dependencies = [
+ "arrayvec",
+ "bitflags 1.3.2",
+ "bytemuck",
+ "lazy_static",
+ "log",
+]
+
+[[package]]
+name = "symphonia-format-caf"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8faf379316b6b6e6bbc274d00e7a592e0d63ff1a7e182ce8ba25e24edd3d096"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-format-isomp4"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "243739585d11f81daf8dac8d9f3d18cc7898f6c09a259675fc364b382c30e0a5"
+dependencies = [
+ "encoding_rs",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-format-mkv"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "122d786d2c43a49beb6f397551b4a050d8229eaa54c7ddf9ee4b98899b8742d0"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-format-ogg"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b4955c67c1ed3aa8ae8428d04ca8397fbef6a19b2b051e73b5da8b1435639cb"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-format-riff"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d7c3df0e7d94efb68401d81906eae73c02b40d5ec1a141962c592d0f11a96f"
+dependencies = [
+ "extended",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-metadata"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36306ff42b9ffe6e5afc99d49e121e0bd62fe79b9db7b9681d48e29fa19e6b16"
+dependencies = [
+ "encoding_rs",
+ "lazy_static",
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-utils-xiph"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27c85ab799a338446b68eec77abf42e1a6f1bb490656e121c6e27bfbab9f16"
+dependencies = [
+ "symphonia-core",
+ "symphonia-metadata",
 ]
 
 [[package]]
@@ -6310,6 +6723,7 @@ dependencies = [
  "portpicker",
  "rand 0.8.6",
  "reqwest 0.12.28",
+ "rodio",
  "serde",
  "serde_json",
  "tauri",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -298,6 +298,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "audiopus_sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62314a1546a2064e033665d658e88c620a62904be945f8147e6b16c3db9f8651"
+dependencies = [
+ "cmake",
+ "log",
+ "pkg-config",
+]
+
+[[package]]
 name = "auto-launch"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -603,6 +614,15 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -3016,6 +3036,15 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "opus"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3809943dff6fbad5f0484449ea26bdb9cb7d8efdf26ed50d3c7f227f69eb5c"
+dependencies = [
+ "audiopus_sys",
+]
 
 [[package]]
 name = "ordered-stream"
@@ -6720,12 +6749,14 @@ dependencies = [
  "notify",
  "objc2",
  "objc2-foundation",
+ "opus",
  "portpicker",
  "rand 0.8.6",
  "reqwest 0.12.28",
  "rodio",
  "serde",
  "serde_json",
+ "symphonia",
  "tauri",
  "tauri-build",
  "tauri-plugin-autostart",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6736,7 +6736,7 @@ checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zuno"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -41,6 +41,13 @@ futures-util = "0.3.33"
 # and the semaphore that serialises playback fills.
 tokio = { version = "1", features = ["sync", "time"] }
 rodio = { version = "0.22.2", default-features = false, features = ["playback", "symphonia-all"] }
+# Demuxing only, and pinned to the version rodio already pulls so the binary carries one copy
+# of the Matroska/Ogg readers rather than two.
+symphonia = { version = "0.5", default-features = false, features = ["mkv", "ogg"] }
+# libopus, built from source via cmake. symphonia has no Opus decoder at all, and YouTube
+# serves Opus-in-WebM for the large majority of tracks at `high` — and as the *only* audio
+# offered for many of them, so preferring AAC is not an alternative.
+opus = "0.3.1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 aes-gcm = "0.10"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zuno"
-version = "1.2.2"
+version = "1.3.0"
 description = "Zuno - a desktop music client"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -39,6 +39,7 @@ notify = "8.2.0"
 futures-util = "0.3.33"
 # Already in the tree via tauri; declared directly only for `sleep` in the range-retry backoff.
 tokio = { version = "1", features = ["time"] }
+rodio = { version = "0.22.2", default-features = false, features = ["playback", "symphonia-all"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 aes-gcm = "0.10"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -37,8 +37,9 @@ md5 = "0.8.0"
 lofty = "0.24.0"
 notify = "8.2.0"
 futures-util = "0.3.33"
-# Already in the tree via tauri; declared directly only for `sleep` in the range-retry backoff.
-tokio = { version = "1", features = ["time"] }
+# Already in the tree via tauri; declared directly for `sleep` in the range-retry backoff
+# and the semaphore that serialises playback fills.
+tokio = { version = "1", features = ["sync", "time"] }
 rodio = { version = "0.22.2", default-features = false, features = ["playback", "symphonia-all"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/src-tauri/src/audio.rs
+++ b/src-tauri/src/audio.rs
@@ -1,0 +1,566 @@
+/*!
+ * Native decode and output.
+ *
+ * symphonia decodes, cpal plays, rodio wires the two together and resamples to whatever the
+ * output device wants. This exists to replace the hidden `youtube.com` IFrame — a whole
+ * subframe process, roughly 90 MB — and the `<audio>` element behind it.
+ *
+ * Two sinks stand in for the two IFrame decks. The next track is decoded and appended to the
+ * standby sink while the current one is still playing, so a handover is a volume ramp between
+ * two live sinks rather than a stop followed by a load. That is what makes gapless and
+ * crossfade work here, which they never did on the `<audio>` path.
+ *
+ * Everything runs on one owned thread behind a channel. cpal's stream handle is not `Send` on
+ * every backend and Tauri state must be, so nothing but the `Sender` leaves this module. The
+ * same thread runs the position tick out of its own `recv_timeout`, rather than a second thread
+ * contending for the same state.
+ */
+
+use std::io::{self, Read, Seek, SeekFrom};
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError, Sender};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use rodio::stream::{DeviceSinkBuilder, MixerDeviceSink};
+use rodio::{Player, Source};
+use serde::Serialize;
+use tauri::{AppHandle, Emitter};
+
+use crate::MediaBuffer;
+
+/// How often position is reported and the end of a track is checked for.
+///
+/// Matches `TRANSITION_TICK_MS` in `PlayerController`, which is what consumes it — a faster
+/// feed would be redundant, a slower one would make the progress bar visibly step.
+const TICK: Duration = Duration::from_millis(250);
+
+/// Ramp granularity during a crossfade. 50 steps a second is well below what the ear resolves
+/// as stepping, and the thread is otherwise idle.
+const FADE_STEP: Duration = Duration::from_millis(20);
+
+/// How long a decoder read waits for bytes that have not landed yet before giving up.
+const READ_TIMEOUT: Duration = Duration::from_secs(20);
+/// Poll interval while waiting on the download. Short enough to be inaudible.
+const READ_POLL: Duration = Duration::from_millis(10);
+
+/// A decoded stream ready to be handed to a deck. rodio resamples it to the device's rate.
+pub(crate) type BoxedSource = Box<dyn Source + Send>;
+
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PositionEvent {
+    track_id: String,
+    position_sec: f64,
+    duration_sec: f64,
+}
+
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct EndedEvent {
+    track_id: String,
+}
+
+/**
+ * A `Read + Seek` view over a body that is still downloading.
+ *
+ * This is what lets the first sample play before the last byte arrives: the decoder reads the
+ * container header out of the head chunk while the rest is still in flight. `MediaBuffer` only
+ * reports its contiguous prefix, so a read never sees a hole — it waits for one to fill.
+ *
+ * ponytail: the wait happens on rodio's mixing thread, so a connection that falls behind
+ * playback is an audible stall rather than a dropped track. Move decoding onto its own thread
+ * behind a bounded channel if that ever shows up in practice; with a 128 KiB head chunk and a
+ * ~160 kbps stream there is a large margin.
+ */
+pub(crate) struct BufferReader {
+    buffer: Arc<Mutex<MediaBuffer>>,
+    position: usize,
+}
+
+impl BufferReader {
+    pub(crate) fn new(buffer: Arc<Mutex<MediaBuffer>>) -> Self {
+        Self { buffer, position: 0 }
+    }
+
+    /// `(contiguous_len, total, failed)` — read under one lock so the three cannot disagree.
+    fn state(&self) -> io::Result<(usize, usize, bool)> {
+        let guard = self
+            .buffer
+            .lock()
+            .map_err(|_| io::Error::other("audio buffer lock poisoned"))?;
+        Ok((guard.contiguous_len(), guard.total, guard.failed))
+    }
+}
+
+impl Read for BufferReader {
+    fn read(&mut self, out: &mut [u8]) -> io::Result<usize> {
+        if out.is_empty() {
+            return Ok(0);
+        }
+
+        let deadline = Instant::now() + READ_TIMEOUT;
+        loop {
+            let (available, total, failed) = self.state()?;
+
+            if self.position >= total {
+                return Ok(0);
+            }
+            if available > self.position {
+                let end = (self.position + out.len()).min(available).min(total) - 1;
+                let bytes = {
+                    let guard = self
+                        .buffer
+                        .lock()
+                        .map_err(|_| io::Error::other("audio buffer lock poisoned"))?;
+                    guard.read(self.position, end)
+                };
+                if bytes.is_empty() {
+                    return Ok(0);
+                }
+                out[..bytes.len()].copy_from_slice(&bytes);
+                self.position += bytes.len();
+                return Ok(bytes.len());
+            }
+            /*
+             * A failed download reports EOF rather than an error. The decoder then finishes the
+             * frames it already has and the track ends early, which is a truncated song instead
+             * of a dead sink that never reports `ended` and hangs the queue.
+             */
+            if failed {
+                return Ok(0);
+            }
+            if Instant::now() >= deadline {
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "timed out waiting for audio bytes",
+                ));
+            }
+            std::thread::sleep(READ_POLL);
+        }
+    }
+}
+
+impl Seek for BufferReader {
+    fn seek(&mut self, from: SeekFrom) -> io::Result<u64> {
+        let (_, total, _) = self.state()?;
+        let target = match from {
+            SeekFrom::Start(offset) => offset as i64,
+            SeekFrom::Current(delta) => self.position as i64 + delta,
+            SeekFrom::End(delta) => total as i64 + delta,
+        };
+        if target < 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "seek before the start of the audio body",
+            ));
+        }
+        /*
+         * Seeking past what has arrived is allowed and does not wait. The next `read` is where
+         * the wait belongs — symphonia probes by seeking around the container, and blocking on
+         * a seek it may never read from would stall a load for no reason.
+         */
+        self.position = (target as usize).min(total);
+        Ok(self.position as u64)
+    }
+}
+
+struct Deck {
+    sink: Player,
+    track_id: Option<String>,
+    duration_sec: f64,
+}
+
+impl Deck {
+    fn clear(&mut self) {
+        self.sink.stop();
+        self.track_id = None;
+        self.duration_sec = 0.0;
+    }
+}
+
+/// An in-progress crossfade. Held so the tick can advance it a step at a time instead of the
+/// command loop sleeping through it and starving position events.
+struct Fade {
+    started_at: Instant,
+    duration: Duration,
+    /// The deck being faded out — already the standby by the time this exists.
+    outgoing: usize,
+}
+
+pub(crate) enum Command {
+    Load {
+        track_id: String,
+        source: BoxedSource,
+        /// The provider's own duration, used when the container does not declare one — Opus in
+        /// WebM usually does not, and a zero duration would break preload timing upstream.
+        fallback_duration_sec: f64,
+        decoded_duration_sec: Option<f64>,
+        standby: bool,
+        reply: Sender<Result<f64, String>>,
+    },
+    Play(Sender<Result<(), String>>),
+    Pause,
+    Stop,
+    Seek(f64),
+    Volume {
+        volume: f32,
+        muted: bool,
+    },
+    Rate(f32),
+    Transition {
+        track_id: String,
+        fade_ms: u64,
+        reply: Sender<bool>,
+    },
+    /// Whether `track_id` is sitting decoded on the standby deck.
+    HasStandby {
+        track_id: String,
+        reply: Sender<bool>,
+    },
+    DropStandby,
+}
+
+/// The handle held as Tauri state. Cheap to clone, trivially `Send + Sync`.
+pub(crate) struct NativeAudio {
+    sender: Mutex<Option<Sender<Command>>>,
+    app: AppHandle,
+}
+
+impl NativeAudio {
+    pub(crate) fn new(app: AppHandle) -> Self {
+        Self { sender: Mutex::new(None), app }
+    }
+
+    /**
+     * Starts the audio thread on first use.
+     *
+     * Deliberately lazy: opening an output device claims a real handle from the OS mixer, and a
+     * user on the IFrame engine should never pay for one. A failure here is what a machine with
+     * no working audio device reports, so it is surfaced rather than swallowed.
+     */
+    pub(crate) fn send(&self, command: Command) -> Result<(), String> {
+        let mut slot = self
+            .sender
+            .lock()
+            .map_err(|_| "native audio lock poisoned".to_string())?;
+
+        if slot.is_none() {
+            let (tx, rx) = mpsc::channel();
+            let (ready_tx, ready_rx) = mpsc::channel();
+            let app = self.app.clone();
+            std::thread::Builder::new()
+                .name("zuno-audio".into())
+                .spawn(move || run(app, rx, ready_tx))
+                .map_err(|error| format!("audio thread failed to start: {error}"))?;
+
+            ready_rx
+                .recv()
+                .map_err(|_| "audio thread stopped before it was ready".to_string())??;
+            *slot = Some(tx);
+        }
+
+        slot.as_ref()
+            .expect("sender was just installed")
+            .send(command)
+            .map_err(|_| "audio thread is gone".to_string())
+    }
+}
+
+/// Sends a command and waits for its reply, mapping a dead thread to an error rather than a
+/// hang. Every reply channel in `Command` is a one-shot, so a single `recv` is the whole
+/// protocol.
+pub(crate) fn request<T>(
+    state: &NativeAudio,
+    build: impl FnOnce(Sender<T>) -> Command,
+) -> Result<T, String> {
+    let (tx, rx) = mpsc::channel();
+    state.send(build(tx))?;
+    rx.recv()
+        .map_err(|_| "audio thread dropped the request".to_string())
+}
+
+fn run(app: AppHandle, rx: Receiver<Command>, ready: Sender<Result<(), String>>) {
+    let stream = match DeviceSinkBuilder::open_default_sink() {
+        Ok(stream) => stream,
+        Err(error) => {
+            let _ = ready.send(Err(format!("no audio output device: {error}")));
+            return;
+        }
+    };
+    let decks = [
+        Deck { sink: Player::connect_new(stream.mixer()), track_id: None, duration_sec: 0.0 },
+        Deck { sink: Player::connect_new(stream.mixer()), track_id: None, duration_sec: 0.0 },
+    ];
+    for deck in &decks {
+        deck.sink.pause();
+    }
+
+    let mut engine = Engine {
+        app,
+        _stream: stream,
+        decks,
+        active: 0,
+        volume: 1.0,
+        muted: false,
+        rate: 1.0,
+        playing: false,
+        fade: None,
+    };
+
+    if ready.send(Ok(())).is_err() {
+        return;
+    }
+
+    let mut next_tick = Instant::now() + TICK;
+    loop {
+        let now = Instant::now();
+        let until_tick = next_tick.saturating_duration_since(now);
+        // A fade needs finer steps than the position tick, so whichever is due first wins.
+        let timeout = if engine.fade.is_some() { until_tick.min(FADE_STEP) } else { until_tick };
+
+        match rx.recv_timeout(timeout) {
+            Ok(command) => {
+                if engine.handle(command) {
+                    return;
+                }
+            }
+            Err(RecvTimeoutError::Timeout) => {}
+            // Every sender is gone, which only happens at shutdown.
+            Err(RecvTimeoutError::Disconnected) => return,
+        }
+
+        engine.advance_fade();
+        if Instant::now() >= next_tick {
+            engine.tick();
+            next_tick = Instant::now() + TICK;
+        }
+    }
+}
+
+struct Engine {
+    app: AppHandle,
+    /// Dropping this closes the output device, so it outlives every deck connected to it.
+    _stream: MixerDeviceSink,
+    decks: [Deck; 2],
+    active: usize,
+    volume: f32,
+    muted: bool,
+    rate: f32,
+    playing: bool,
+    fade: Option<Fade>,
+}
+
+impl Engine {
+    fn standby(&self) -> usize {
+        1 - self.active
+    }
+
+    fn output_volume(&self) -> f32 {
+        if self.muted {
+            0.0
+        } else {
+            self.volume
+        }
+    }
+
+    /// Returns true when the thread should stop.
+    fn handle(&mut self, command: Command) -> bool {
+        match command {
+            Command::Load {
+                track_id,
+                source,
+                fallback_duration_sec,
+                decoded_duration_sec,
+                standby,
+                reply,
+            } => {
+                let index = if standby { self.standby() } else { self.active };
+                if !standby {
+                    // A fade against a deck that is being reloaded would ramp a track that is
+                    // no longer there.
+                    self.cancel_fade();
+                }
+                let duration = decoded_duration_sec
+                    .filter(|value| *value > 0.0)
+                    .unwrap_or(fallback_duration_sec)
+                    .max(0.0);
+
+                /*
+                 * The standby is silent until a transition ramps it up. A deck that inherited
+                 * the output volume would be audible the instant it was started, and a gapless
+                 * swap starts it in the same tick it becomes active.
+                 */
+                let volume = if standby { 0.0 } else { self.output_volume() };
+                let rate = self.rate;
+
+                let deck = &mut self.decks[index];
+                deck.sink.stop();
+                deck.sink.append(source);
+                deck.sink.pause();
+                deck.sink.set_volume(volume);
+                deck.sink.set_speed(rate);
+                deck.track_id = Some(track_id);
+                deck.duration_sec = duration;
+
+                if !standby {
+                    self.playing = false;
+                }
+                let _ = reply.send(Ok(duration));
+            }
+            Command::Play(reply) => {
+                /*
+                 * A crossfade already started this deck and owns its volume. The player calls
+                 * `play` right after a transition to take the claim, and writing full volume
+                 * here would jump the ramp to its end for the rest of the fade window.
+                 */
+                let volume = self.fade.is_none().then(|| self.output_volume());
+                let deck = &mut self.decks[self.active];
+                if deck.track_id.is_none() {
+                    let _ = reply.send(Err("no track is loaded".to_string()));
+                    return false;
+                }
+                if let Some(volume) = volume {
+                    deck.sink.set_volume(volume);
+                }
+                deck.sink.play();
+                self.playing = true;
+                let _ = reply.send(Ok(()));
+            }
+            Command::Pause => {
+                self.decks[self.active].sink.pause();
+                self.playing = false;
+            }
+            Command::Stop => {
+                self.cancel_fade();
+                for deck in &mut self.decks {
+                    deck.clear();
+                }
+                self.playing = false;
+            }
+            Command::Seek(seconds) => {
+                let target = Duration::from_secs_f64(seconds.max(0.0));
+                if let Err(error) = self.decks[self.active].sink.try_seek(target) {
+                    eprintln!("[internal][tauri][warn] native audio seek failed: {error}");
+                }
+            }
+            Command::Volume { volume, muted } => {
+                self.volume = volume.clamp(0.0, 1.0);
+                self.muted = muted;
+                // A fade owns both volumes until it finishes; writing here would jump the ramp.
+                if self.fade.is_none() {
+                    self.decks[self.active].sink.set_volume(self.output_volume());
+                }
+            }
+            Command::Rate(rate) => {
+                self.rate = rate.clamp(0.25, 4.0);
+                for deck in &self.decks {
+                    deck.sink.set_speed(self.rate);
+                }
+            }
+            Command::Transition { track_id, fade_ms, reply } => {
+                let standby = self.standby();
+                if self.decks[standby].track_id.as_deref() != Some(track_id.as_str()) {
+                    let _ = reply.send(false);
+                    return false;
+                }
+
+                self.cancel_fade();
+                let target = self.output_volume();
+                self.decks[standby]
+                    .sink
+                    .set_volume(if fade_ms > 0 { 0.0 } else { target });
+                self.decks[standby].sink.set_speed(self.rate);
+                self.decks[standby].sink.play();
+
+                let outgoing = self.active;
+                self.active = standby;
+                self.playing = true;
+
+                if fade_ms > 0 {
+                    self.fade = Some(Fade {
+                        started_at: Instant::now(),
+                        duration: Duration::from_millis(fade_ms),
+                        outgoing,
+                    });
+                } else {
+                    self.decks[outgoing].clear();
+                }
+                let _ = reply.send(true);
+            }
+            Command::HasStandby { track_id, reply } => {
+                let standby = self.standby();
+                let matched = self.decks[standby].track_id.as_deref() == Some(track_id.as_str());
+                let _ = reply.send(matched);
+            }
+            Command::DropStandby => {
+                let standby = self.standby();
+                self.decks[standby].clear();
+            }
+        }
+        false
+    }
+
+    fn cancel_fade(&mut self) {
+        if self.fade.take().is_some() {
+            let volume = self.output_volume();
+            self.decks[self.active].sink.set_volume(volume);
+        }
+    }
+
+    /// Moves an in-progress crossfade one step, and finishes it when the window closes.
+    fn advance_fade(&mut self) {
+        let Some(fade) = &self.fade else { return };
+        let progress = (fade.started_at.elapsed().as_secs_f32()
+            / fade.duration.as_secs_f32().max(f32::EPSILON))
+        .clamp(0.0, 1.0);
+        let outgoing = fade.outgoing;
+        let target = self.output_volume();
+
+        /*
+         * Equal-power rather than linear. Two linear ramps crossing at half volume sum to an
+         * audible dip in the middle, because loudness is not proportional to amplitude; the
+         * sine/cosine pair holds perceived level constant across the transition.
+         */
+        self.decks[outgoing]
+            .sink
+            .set_volume(target * (progress * std::f32::consts::FRAC_PI_2).cos());
+        self.decks[self.active]
+            .sink
+            .set_volume(target * (progress * std::f32::consts::FRAC_PI_2).sin());
+
+        if progress >= 1.0 {
+            self.fade = None;
+            self.decks[outgoing].clear();
+            self.decks[self.active].sink.set_volume(target);
+        }
+    }
+
+    fn tick(&mut self) {
+        let index = self.active;
+        let Some(track_id) = self.decks[index].track_id.clone() else { return };
+
+        /*
+         * An empty sink means the decoder ran out, which is the only end-of-track signal there
+         * is. Suppressed mid-fade: the outgoing deck emptying there is the transition working,
+         * not the new track finishing.
+         */
+        if self.playing && self.fade.is_none() && self.decks[index].sink.empty() {
+            self.decks[index].clear();
+            self.playing = false;
+            let _ = self.app.emit("native-audio-ended", EndedEvent { track_id });
+            return;
+        }
+
+        if !self.playing {
+            return;
+        }
+        let _ = self.app.emit(
+            "native-audio-position",
+            PositionEvent {
+                track_id,
+                position_sec: self.decks[index].sink.get_pos().as_secs_f64(),
+                duration_sec: self.decks[index].duration_sec,
+            },
+        );
+    }
+}

--- a/src-tauri/src/audio.rs
+++ b/src-tauri/src/audio.rs
@@ -24,6 +24,7 @@ use std::time::{Duration, Instant};
 use rodio::stream::{DeviceSinkBuilder, MixerDeviceSink};
 use rodio::{Player, Source};
 use serde::Serialize;
+use symphonia::core::io::MediaSource;
 use tauri::{AppHandle, Emitter};
 
 use crate::MediaBuffer;
@@ -137,6 +138,23 @@ impl Read for BufferReader {
             }
             std::thread::sleep(READ_POLL);
         }
+    }
+}
+
+/**
+ * Seekable and self-describing, so symphonia can probe a container it is still downloading.
+ *
+ * `byte_len` comes from the URL's own `clen` rather than from what has arrived — the demuxer
+ * uses it to locate the tail of a Matroska file, and answering with the current fill would
+ * point it at the middle of the download.
+ */
+impl MediaSource for BufferReader {
+    fn is_seekable(&self) -> bool {
+        true
+    }
+
+    fn byte_len(&self) -> Option<u64> {
+        self.state().ok().map(|(_, total, _)| total as u64)
     }
 }
 

--- a/src-tauri/src/equalizer.rs
+++ b/src-tauri/src/equalizer.rs
@@ -1,0 +1,369 @@
+/*!
+ * Ten-band graphic equaliser.
+ *
+ * A cascade of peaking biquads between the decoder and the deck. This is only possible at all
+ * because the Rust engine owns the samples: the IFrame player never exposes them, and the
+ * `<audio>` path would need a second implementation in Web Audio.
+ *
+ * The settings are process-global rather than per-source. Two decks are live during a crossfade
+ * and both have to sound the same, and a slider has to move the track *playing*, not the next
+ * one — so a source reads shared state rather than capturing gains when it was built.
+ */
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
+use std::time::Duration;
+
+use rodio::{ChannelCount, SampleRate, Source};
+
+/// ISO octave centres. The familiar ten sliders.
+pub(crate) const BAND_HZ: [f32; 10] =
+    [31.0, 62.0, 125.0, 250.0, 500.0, 1_000.0, 2_000.0, 4_000.0, 8_000.0, 16_000.0];
+pub(crate) const BAND_COUNT: usize = BAND_HZ.len();
+
+/**
+ * Q for one-octave bands: `1 / (2 * sinh(ln2 / 2 * bandwidth))` with bandwidth 1.
+ *
+ * Wider (lower Q) and neighbouring sliders fight each other, so moving one visibly changes two;
+ * narrower and a boost is a whistle rather than a tone control.
+ */
+const BAND_Q: f32 = 1.414_213_6;
+
+/// Gains beyond this are not tone control any more, and the preamp cannot buy back the headroom.
+const MAX_GAIN_DB: f32 = 12.0;
+
+#[derive(Clone, Copy, PartialEq)]
+pub(crate) struct EqualizerValues {
+    pub(crate) preamp_db: f32,
+    pub(crate) bands_db: [f32; BAND_COUNT],
+}
+
+impl EqualizerValues {
+    pub(crate) const FLAT: Self = Self { preamp_db: 0.0, bands_db: [0.0; BAND_COUNT] };
+
+    /// Nothing to do — the filters are bypassed entirely rather than run at unity.
+    fn is_flat(&self) -> bool {
+        self.preamp_db == 0.0 && self.bands_db.iter().all(|gain| *gain == 0.0)
+    }
+
+    fn clamped(mut self) -> Self {
+        self.preamp_db = self.preamp_db.clamp(-MAX_GAIN_DB, MAX_GAIN_DB);
+        for gain in &mut self.bands_db {
+            *gain = gain.clamp(-MAX_GAIN_DB, MAX_GAIN_DB);
+        }
+        self
+    }
+}
+
+struct EqualizerState {
+    /**
+     * Bumped on every change.
+     *
+     * A live source checks this per sample — one relaxed atomic load, a few nanoseconds — and
+     * only takes the lock when it actually moved. Locking per sample on the mixing thread would
+     * put a mutex in the audio path, which is the one place it must not be.
+     */
+    generation: AtomicU64,
+    values: Mutex<EqualizerValues>,
+}
+
+static EQUALIZER: EqualizerState = EqualizerState {
+    generation: AtomicU64::new(0),
+    values: Mutex::new(EqualizerValues::FLAT),
+};
+
+pub(crate) fn set_values(values: EqualizerValues) {
+    if let Ok(mut guard) = EQUALIZER.values.lock() {
+        *guard = values.clamped();
+    }
+    // Published after the write, so a source that sees the new generation sees the new values.
+    EQUALIZER.generation.fetch_add(1, Ordering::Release);
+}
+
+pub(crate) fn values() -> EqualizerValues {
+    EQUALIZER
+        .values
+        .lock()
+        .map(|guard| *guard)
+        .unwrap_or(EqualizerValues::FLAT)
+}
+
+/**
+ * One peaking filter, direct form I.
+ *
+ * The coefficients are the RBJ cookbook's peaking EQ. Direct form I rather than II because it
+ * holds its state in the input and output history, which stays well behaved when the
+ * coefficients change under it — and here they change every time a slider moves, mid-note.
+ */
+#[derive(Clone, Copy)]
+struct Biquad {
+    b0: f32,
+    b1: f32,
+    b2: f32,
+    a1: f32,
+    a2: f32,
+    x1: f32,
+    x2: f32,
+    y1: f32,
+    y2: f32,
+}
+
+impl Biquad {
+    const PASSTHROUGH: Self = Self {
+        b0: 1.0,
+        b1: 0.0,
+        b2: 0.0,
+        a1: 0.0,
+        a2: 0.0,
+        x1: 0.0,
+        x2: 0.0,
+        y1: 0.0,
+        y2: 0.0,
+    };
+
+    fn peaking(frequency: f32, sample_rate: f32, gain_db: f32) -> Self {
+        // Above Nyquist there is nothing to boost, and the coefficients go to nonsense.
+        if gain_db == 0.0 || frequency >= sample_rate / 2.0 {
+            return Self::PASSTHROUGH;
+        }
+
+        let amplitude = 10f32.powf(gain_db / 40.0);
+        let omega = std::f32::consts::TAU * frequency / sample_rate;
+        let (sin, cos) = omega.sin_cos();
+        let alpha = sin / (2.0 * BAND_Q);
+
+        let a0 = 1.0 + alpha / amplitude;
+        Self {
+            b0: (1.0 + alpha * amplitude) / a0,
+            b1: (-2.0 * cos) / a0,
+            b2: (1.0 - alpha * amplitude) / a0,
+            a1: (-2.0 * cos) / a0,
+            a2: (1.0 - alpha / amplitude) / a0,
+            // History is deliberately preserved by the caller; only the coefficients are new.
+            ..Self::PASSTHROUGH
+        }
+    }
+
+    #[inline]
+    fn process(&mut self, input: f32) -> f32 {
+        let output = self.b0 * input + self.b1 * self.x1 + self.b2 * self.x2
+            - self.a1 * self.y1
+            - self.a2 * self.y2;
+        self.x2 = self.x1;
+        self.x1 = input;
+        self.y2 = self.y1;
+        self.y1 = output;
+        output
+    }
+
+    /// Swaps in new coefficients without disturbing the sample history, so a slider moved during
+    /// a note retunes the filter rather than restarting it with a click.
+    fn retune(&mut self, next: Self) {
+        self.b0 = next.b0;
+        self.b1 = next.b1;
+        self.b2 = next.b2;
+        self.a1 = next.a1;
+        self.a2 = next.a2;
+    }
+}
+
+/// Wraps a decoded stream in the equaliser. Cheap when flat: the filters are skipped entirely.
+pub(crate) struct EqualizedSource<S> {
+    inner: S,
+    sample_rate: f32,
+    /// Per channel, because a biquad's history is per signal — sharing one across an interleaved
+    /// stream filters left against right and produces a mess.
+    filters: Vec<[Biquad; BAND_COUNT]>,
+    channel_index: usize,
+    preamp: f32,
+    bypass: bool,
+    generation: u64,
+}
+
+impl<S: Source> EqualizedSource<S> {
+    pub(crate) fn new(inner: S) -> Self {
+        let channels = inner.channels().get() as usize;
+        let sample_rate = inner.sample_rate().get() as f32;
+        let mut source = Self {
+            inner,
+            sample_rate,
+            filters: vec![[Biquad::PASSTHROUGH; BAND_COUNT]; channels.max(1)],
+            channel_index: 0,
+            preamp: 1.0,
+            bypass: true,
+            // Not the live generation: starting one behind forces the first sample to load
+            // whatever the user already had set before this track began.
+            generation: u64::MAX,
+        };
+        source.reload();
+        source
+    }
+
+    fn reload(&mut self) {
+        self.generation = EQUALIZER.generation.load(Ordering::Acquire);
+        let values = values();
+        self.bypass = values.is_flat();
+        if self.bypass {
+            return;
+        }
+
+        self.preamp = 10f32.powf(values.preamp_db / 20.0);
+        for channel in &mut self.filters {
+            for (band, filter) in channel.iter_mut().enumerate() {
+                filter.retune(Biquad::peaking(BAND_HZ[band], self.sample_rate, values.bands_db[band]));
+            }
+        }
+    }
+}
+
+impl<S: Source> Iterator for EqualizedSource<S> {
+    type Item = f32;
+
+    #[inline]
+    fn next(&mut self) -> Option<f32> {
+        let sample = self.inner.next()?;
+
+        if self.generation != EQUALIZER.generation.load(Ordering::Acquire) {
+            self.reload();
+        }
+        if self.bypass {
+            return Some(sample);
+        }
+
+        let channel = self.channel_index;
+        self.channel_index = (self.channel_index + 1) % self.filters.len();
+
+        let mut output = sample * self.preamp;
+        for filter in &mut self.filters[channel] {
+            output = filter.process(output);
+        }
+        Some(output)
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}
+
+impl<S: Source> Source for EqualizedSource<S> {
+    #[inline]
+    fn current_span_len(&self) -> Option<usize> {
+        self.inner.current_span_len()
+    }
+
+    #[inline]
+    fn channels(&self) -> ChannelCount {
+        self.inner.channels()
+    }
+
+    #[inline]
+    fn sample_rate(&self) -> SampleRate {
+        self.inner.sample_rate()
+    }
+
+    #[inline]
+    fn total_duration(&self) -> Option<Duration> {
+        self.inner.total_duration()
+    }
+
+    fn try_seek(&mut self, position: Duration) -> Result<(), rodio::source::SeekError> {
+        self.inner.try_seek(position)?;
+        /*
+         * The filter history describes audio from before the jump. Carrying it across is a
+         * transient built from samples that are no longer adjacent — a thump on every seek.
+         */
+        for channel in &mut self.filters {
+            for filter in channel.iter_mut() {
+                filter.x1 = 0.0;
+                filter.x2 = 0.0;
+                filter.y1 = 0.0;
+                filter.y2 = 0.0;
+            }
+        }
+        self.channel_index = 0;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Biquad, EqualizerValues, BAND_COUNT, BAND_HZ, MAX_GAIN_DB};
+
+    /// Runs a sine through a filter and returns its amplitude once the state has settled.
+    fn response_at(mut filter: Biquad, frequency: f32, sample_rate: f32) -> f32 {
+        let step = std::f32::consts::TAU * frequency / sample_rate;
+        // Long enough for the transient to decay before anything is measured.
+        for n in 0..4_000 {
+            filter.process((n as f32 * step).sin());
+        }
+        let mut peak = 0.0f32;
+        for n in 4_000..8_000 {
+            peak = peak.max(filter.process((n as f32 * step).sin()).abs());
+        }
+        peak
+    }
+
+    /**
+     * A band boosts its own centre and leaves the far end of the spectrum alone.
+     *
+     * The arithmetic is easy to get subtly wrong — a swapped sign or a missed `a0` division
+     * produces a filter that still runs and still makes sound, just the wrong sound, which is
+     * exactly the kind of bug that survives to a release.
+     */
+    #[test]
+    fn a_band_boosts_its_own_centre_and_leaves_the_rest_alone() {
+        let sample_rate = 48_000.0;
+        let boosted = Biquad::peaking(1_000.0, sample_rate, 12.0);
+
+        let at_centre = response_at(boosted, 1_000.0, sample_rate);
+        // +12 dB is a gain of about 4. Generous bounds: this is checking the shape, not the ripple.
+        assert!(
+            at_centre > 3.5 && at_centre < 4.5,
+            "+12 dB at the centre should be roughly 4x, got {at_centre}",
+        );
+
+        let far_below = response_at(boosted, 60.0, sample_rate);
+        let far_above = response_at(boosted, 16_000.0, sample_rate);
+        assert!(far_below < 1.2, "a 1 kHz band must not lift 60 Hz: {far_below}");
+        assert!(far_above < 1.2, "a 1 kHz band must not lift 16 kHz: {far_above}");
+
+        // A cut is the same filter with the gain the other way.
+        let cut = response_at(Biquad::peaking(1_000.0, sample_rate, -12.0), 1_000.0, sample_rate);
+        assert!(cut > 0.2 && cut < 0.3, "-12 dB should be roughly a quarter, got {cut}");
+    }
+
+    /// Zero gain must be exactly transparent, and a band above Nyquist must not produce garbage.
+    #[test]
+    fn nothing_to_do_means_nothing_is_done() {
+        let flat = Biquad::peaking(1_000.0, 48_000.0, 0.0);
+        assert_eq!(flat.b0, 1.0);
+        assert_eq!(flat.b1, 0.0);
+        assert_eq!(flat.a1, 0.0);
+
+        // 16 kHz has no meaning at an 8 kHz sample rate; the coefficients would be nonsense.
+        let above_nyquist = Biquad::peaking(16_000.0, 8_000.0, 12.0);
+        assert_eq!(above_nyquist.b0, 1.0);
+        let passed = response_at(above_nyquist, 1_000.0, 8_000.0);
+        assert!((passed - 1.0).abs() < 0.01, "a disabled band is unity gain, got {passed}");
+    }
+
+    #[test]
+    fn gains_are_clamped_and_flat_is_recognised() {
+        assert!(EqualizerValues::FLAT.is_flat());
+        assert_eq!(BAND_HZ.len(), BAND_COUNT);
+
+        let mut shouted = EqualizerValues::FLAT;
+        shouted.preamp_db = 99.0;
+        shouted.bands_db[3] = -99.0;
+        let clamped = shouted.clamped();
+        assert_eq!(clamped.preamp_db, MAX_GAIN_DB);
+        assert_eq!(clamped.bands_db[3], -MAX_GAIN_DB);
+        assert!(!clamped.is_flat(), "a clamped setting is still a setting");
+
+        // The preamp alone counts: a pure volume trim must not be optimised away as "flat".
+        let mut trimmed = EqualizerValues::FLAT;
+        trimmed.preamp_db = -3.0;
+        assert!(!trimmed.is_flat());
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3109,7 +3109,17 @@ async fn fill_media_buffer(
             let client = client.clone();
             let url = url.clone();
             let cookie = cookie.clone();
+            let abandoned = Arc::clone(&buffer);
             async move {
+                /*
+                 * Checked here rather than between chunks because `buffered(1)` starts the next
+                 * request as soon as it is polled — by the time the outer loop could look, the
+                 * range is already in flight. `failed` is set by whoever gave up on the body:
+                 * the fill itself, or a decode that could not use it.
+                 */
+                if abandoned.lock().map(|guard| guard.failed).unwrap_or(true) {
+                    return Err((index, cache_error("fill abandoned")));
+                }
                 /*
                  * Retried before it is given up on. A 403 on a range is usually transient —
                  * googlevideo throttling rather than a URL that has gone bad — and abandoning
@@ -3171,6 +3181,18 @@ async fn fill_media_buffer(
                 }
             }
             Err((index, error)) => {
+                /*
+                 * An abandoned fill must not fall back — the fallback downloads the *whole*
+                 * body, which is precisely the work being called off. Only a genuine refusal
+                 * gets the retry below.
+                 */
+                if buffer.lock().map(|guard| guard.failed).unwrap_or(true) {
+                    eprintln!(
+                        "[internal][tauri][info] fill_media_buffer abandoned track_id={}",
+                        track_id
+                    );
+                    return;
+                }
                 /*
                  * One refused range is not a dead track.
                  *
@@ -3250,8 +3272,9 @@ enum NativeAudioSource {
  */
 fn open_native_audio_reader(
     app: &tauri::AppHandle,
+    track_id: &str,
     source: NativeAudioSource,
-) -> Result<Box<dyn NativeAudioRead>, CommandError> {
+) -> Result<NativeAudioReader, CommandError> {
     match source {
         NativeAudioSource::Stream {
             url,
@@ -3269,19 +3292,22 @@ fn open_native_audio_reader(
             let buffer = Arc::new(Mutex::new(MediaBuffer::pending(total, ranges.len())));
             tauri::async_runtime::spawn(fill_media_buffer(
                 url,
-                String::new(),
+                track_id.to_string(),
                 cookie,
                 mime_type,
                 Arc::clone(&buffer),
                 ranges,
             ));
-            Ok(Box::new(audio::BufferReader::new(buffer)))
+            Ok(NativeAudioReader {
+                reader: Box::new(audio::BufferReader::new(Arc::clone(&buffer))),
+                buffer: Some(buffer),
+            })
         }
         NativeAudioSource::Offline { track_id } => {
             let path = offline_entry_path(app, &track_id)?;
             let file = File::open(&path)
                 .map_err(|error| cache_error(format!("offline read failed: {error}")))?;
-            Ok(Box::new(file))
+            Ok(NativeAudioReader { reader: Box::new(file), buffer: None })
         }
         NativeAudioSource::File { path } => {
             let path = PathBuf::from(path);
@@ -3292,9 +3318,21 @@ fn open_native_audio_reader(
             }
             let file = File::open(&path)
                 .map_err(|error| cache_error(format!("local audio read failed: {error}")))?;
-            Ok(Box::new(file))
+            Ok(NativeAudioReader { reader: Box::new(file), buffer: None })
         }
     }
+}
+
+/**
+ * A reader, plus the buffer behind it when one is still filling.
+ *
+ * The buffer comes back so a *failed* decode can abandon the download. Without it a track whose
+ * codec symphonia cannot handle still pulled its whole body over the network — and, worse, held
+ * `PLAYBACK_FILL_LOCK` while doing it, so every refusal delayed the next real load.
+ */
+struct NativeAudioReader {
+    reader: Box<dyn NativeAudioRead>,
+    buffer: Option<Arc<Mutex<MediaBuffer>>>,
 }
 
 /// What rodio's decoder needs of a byte source. Named so the three cases above can be boxed
@@ -3322,10 +3360,10 @@ async fn native_audio_load(
     duration_sec: Option<f64>,
     standby: Option<bool>,
 ) -> Result<f64, CommandError> {
-    let reader = open_native_audio_reader(&app, source)?;
+    let NativeAudioReader { reader, buffer } = open_native_audio_reader(&app, &track_id, source)?;
     let started_at = Instant::now();
 
-    let (decoded, decoded_duration) = tauri::async_runtime::spawn_blocking(move || {
+    let decoded = tauri::async_runtime::spawn_blocking(move || {
         use rodio::Source as _;
         rodio::Decoder::new(reader)
             .map(|decoder| {
@@ -3335,8 +3373,29 @@ async fn native_audio_load(
             .map_err(|error| format!("audio decode failed: {error}"))
     })
     .await
-    .map_err(|error| cache_error(format!("audio decode task failed: {error}")))?
-    .map_err(cache_error)?;
+    .map_err(|error| cache_error(format!("audio decode task failed: {error}")))?;
+
+    /*
+     * A decode that failed has no reader left, so the fill behind it is downloading a body
+     * nobody will ever read. Marking the buffer stops it at its next range and, more to the
+     * point, gives up the fill permit — otherwise a run of undecodable tracks queues a run of
+     * pointless downloads in front of the next one that would have played.
+     */
+    let (decoded, decoded_duration) = match decoded {
+        Ok(decoded) => decoded,
+        Err(message) => {
+            if let Some(buffer) = &buffer {
+                if let Ok(mut guard) = buffer.lock() {
+                    guard.failed = true;
+                }
+            }
+            eprintln!(
+                "[internal][tauri][warn] native_audio_load decode failed track_id={} error={}",
+                track_id, message
+            );
+            return Err(cache_error(message));
+        }
+    };
 
     let duration = audio::request(&state, |reply| audio::Command::Load {
         track_id: track_id.clone(),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3307,9 +3307,13 @@ fn open_native_audio_reader(
         }
         NativeAudioSource::Offline { track_id, mime_type } => {
             let path = offline_entry_path(app, &track_id)?;
-            let file = File::open(&path)
+            let mut file = File::open(&path)
                 .map_err(|error| cache_error(format!("offline read failed: {error}")))?;
-            Ok(NativeAudioReader { reader: Box::new(file), mime_type, buffer: None })
+            Ok(NativeAudioReader {
+                mime_type: sniffed_mime(&mut file, mime_type, &track_id),
+                reader: Box::new(file),
+                buffer: None,
+            })
         }
         NativeAudioSource::File { path } => {
             let path = PathBuf::from(path);
@@ -3318,13 +3322,44 @@ fn open_native_audio_reader(
             if !path.is_file() || !is_local_audio_file(&path) {
                 return Err(cache_error("local audio file is unavailable."));
             }
-            // The extension is the only codec hint a local file carries; the same mapping
-            // `local_audio_read` hands the webview.
-            let mime_type = local_audio_mime_type(&path).to_string();
-            let file = File::open(&path)
+            // The extension is the only codec hint a local file carries, and it is a claim
+            // rather than a fact — the bytes below get the final say.
+            let declared = local_audio_mime_type(&path).to_string();
+            let mut file = File::open(&path)
                 .map_err(|error| cache_error(format!("local audio read failed: {error}")))?;
-            Ok(NativeAudioReader { reader: Box::new(file), mime_type, buffer: None })
+            let label = path.file_name().and_then(|name| name.to_str()).unwrap_or("file");
+            Ok(NativeAudioReader {
+                mime_type: sniffed_mime(&mut file, declared, label),
+                reader: Box::new(file),
+                buffer: None,
+            })
         }
+    }
+}
+
+/**
+ * The container a stored body really is, preferring its own bytes over what was declared.
+ *
+ * Only for things already on disk. A *stream* keeps its declared type: that came from the format
+ * selection which produced the very URL being fetched, so it cannot drift, and sniffing it would
+ * mean waiting on the network before choosing a decoder.
+ */
+fn sniffed_mime(
+    file: &mut File,
+    declared: String,
+    label: &str,
+) -> String {
+    match opus_source::sniff_container_mime(file) {
+        Ok(Some(sniffed)) if sniffed != declared => {
+            eprintln!(
+                "[internal][tauri][info] container sniffed {} declared={} actual={}",
+                label, declared, sniffed
+            );
+            sniffed.to_string()
+        }
+        Ok(_) => declared,
+        // Unreadable here means unreadable for the decoder too; let that report it.
+        Err(_) => declared,
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -42,6 +42,7 @@ mod macos_media;
 #[cfg(target_os = "windows")]
 mod windows_media;
 
+mod audio;
 mod discord_rpc;
 mod lastfm;
 
@@ -1934,12 +1935,12 @@ struct ProxyHttpResponse {
  * for a range past that prefix waits for it rather than being answered short, which is what
  * lets an `<audio>` element start on the first chunk while the rest is still downloading.
  */
-struct MediaBuffer {
+pub(crate) struct MediaBuffer {
     /// Sized on creation; each slot's length is its own chunk size, so no stride is stored.
     chunks: Vec<Option<Vec<u8>>>,
-    total: usize,
+    pub(crate) total: usize,
     /// Set when the download gave up. The server answers 503 rather than waiting out the clock.
-    failed: bool,
+    pub(crate) failed: bool,
 }
 
 impl MediaBuffer {
@@ -1953,7 +1954,7 @@ impl MediaBuffer {
     }
 
     /// Bytes servable from offset 0 without a hole.
-    fn contiguous_len(&self) -> usize {
+    pub(crate) fn contiguous_len(&self) -> usize {
         let mut len = 0;
         for chunk in &self.chunks {
             match chunk {
@@ -1977,7 +1978,7 @@ impl MediaBuffer {
     }
 
     /// Copies `start..=end` out of the chunk list, which may straddle several chunks.
-    fn read(&self, start: usize, end: usize) -> Vec<u8> {
+    pub(crate) fn read(&self, start: usize, end: usize) -> Vec<u8> {
         let mut out = Vec::with_capacity(end.saturating_sub(start) + 1);
         let mut offset = 0;
         for chunk in &self.chunks {
@@ -3134,6 +3135,239 @@ async fn fill_media_buffer(
     }
 }
 
+/* ---------------------------------------------------------------------------------------- *
+ * Native audio engine
+ *
+ * The `<audio>` path above hands bytes to the webview over loopback HTTP and lets Chromium
+ * decode them. These commands hand the same bytes to symphonia instead, so nothing leaves the
+ * Rust process — no media server round trip, no second copy of the song in the renderer, and
+ * two real decks to fade between. `audio.rs` owns the decoding and output; this layer only
+ * resolves a source into something readable and forwards the request.
+ * ---------------------------------------------------------------------------------------- */
+
+/// Where a track's bytes come from. The three cases the player actually has.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", tag = "kind")]
+enum NativeAudioSource {
+    /// A signed googlevideo URL, decoded as it downloads.
+    Stream {
+        url: String,
+        mime_type: String,
+        cookie: Option<String>,
+    },
+    /// A track already in the offline store.
+    Offline { track_id: String },
+    /// A file the user pointed at a music folder.
+    File { path: String },
+}
+
+/**
+ * Opens a source as a blocking reader.
+ *
+ * The streaming case is the interesting one: it publishes an empty buffer sized from the URL's
+ * own `clen`, starts the same ranged fill the media server uses, and returns a reader over it
+ * straight away. The decoder then reads the container header out of the head chunk while the
+ * rest is still arriving — which is the whole difference from the `<audio>` path, where the
+ * body had to be published before an element could be pointed at it.
+ */
+fn open_native_audio_reader(
+    app: &tauri::AppHandle,
+    source: NativeAudioSource,
+) -> Result<Box<dyn NativeAudioRead>, CommandError> {
+    match source {
+        NativeAudioSource::Stream {
+            url,
+            mime_type,
+            cookie,
+        } => {
+            let request_url = url::Url::parse(&url)
+                .map_err(|error| cache_error(format!("audio URL parse failed: {error}")))?;
+            let total = signed_content_length(&request_url).unwrap_or(0) as usize;
+            if total == 0 {
+                return Err(cache_error("audio URL declared no length"));
+            }
+
+            let ranges = playback_ranges(total);
+            let buffer = Arc::new(Mutex::new(MediaBuffer::pending(total, ranges.len())));
+            tauri::async_runtime::spawn(fill_media_buffer(
+                url,
+                String::new(),
+                cookie,
+                mime_type,
+                Arc::clone(&buffer),
+                ranges,
+            ));
+            Ok(Box::new(audio::BufferReader::new(buffer)))
+        }
+        NativeAudioSource::Offline { track_id } => {
+            let path = offline_entry_path(app, &track_id)?;
+            let file = File::open(&path)
+                .map_err(|error| cache_error(format!("offline read failed: {error}")))?;
+            Ok(Box::new(file))
+        }
+        NativeAudioSource::File { path } => {
+            let path = PathBuf::from(path);
+            // Re-validated here rather than trusted from the frontend, exactly as
+            // `local_audio_read` does — this is the same trust boundary.
+            if !path.is_file() || !is_local_audio_file(&path) {
+                return Err(cache_error("local audio file is unavailable."));
+            }
+            let file = File::open(&path)
+                .map_err(|error| cache_error(format!("local audio read failed: {error}")))?;
+            Ok(Box::new(file))
+        }
+    }
+}
+
+/// What rodio's decoder needs of a byte source. Named so the three cases above can be boxed
+/// into one type.
+trait NativeAudioRead: Read + std::io::Seek + Send + Sync {}
+impl<T: Read + std::io::Seek + Send + Sync> NativeAudioRead for T {}
+
+/**
+ * Decodes a track onto a deck.
+ *
+ * `standby` loads it onto the idle deck instead of the playing one, which is what
+ * `native_audio_transition` later swaps to. Returns the duration actually decoded, falling back
+ * to the provider's when the container declares none — Opus in WebM usually does not.
+ *
+ * The decode runs on a blocking pool thread, not on the audio thread: building a decoder reads
+ * the container header, and for a stream that means waiting on the network. Doing it here keeps
+ * the audio thread free to go on reporting the position of the track that is still playing.
+ */
+#[tauri::command]
+async fn native_audio_load(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, audio::NativeAudio>,
+    track_id: String,
+    source: NativeAudioSource,
+    duration_sec: Option<f64>,
+    standby: Option<bool>,
+) -> Result<f64, CommandError> {
+    let reader = open_native_audio_reader(&app, source)?;
+    let started_at = Instant::now();
+
+    let (decoded, decoded_duration) = tauri::async_runtime::spawn_blocking(move || {
+        use rodio::Source as _;
+        rodio::Decoder::new(reader)
+            .map(|decoder| {
+                let duration = decoder.total_duration().map(|value| value.as_secs_f64());
+                (Box::new(decoder) as audio::BoxedSource, duration)
+            })
+            .map_err(|error| format!("audio decode failed: {error}"))
+    })
+    .await
+    .map_err(|error| cache_error(format!("audio decode task failed: {error}")))?
+    .map_err(cache_error)?;
+
+    let duration = audio::request(&state, |reply| audio::Command::Load {
+        track_id: track_id.clone(),
+        source: decoded,
+        fallback_duration_sec: duration_sec.unwrap_or(0.0),
+        decoded_duration_sec: decoded_duration,
+        standby: standby.unwrap_or(false),
+        reply,
+    })
+    .map_err(cache_error)?
+    .map_err(cache_error)?;
+
+    eprintln!(
+        "[internal][tauri][info] native_audio_load track_id={} standby={} duration_sec={} decode_ms={}",
+        track_id,
+        standby.unwrap_or(false),
+        duration,
+        started_at.elapsed().as_millis()
+    );
+    Ok(duration)
+}
+
+#[tauri::command]
+fn native_audio_play(state: tauri::State<'_, audio::NativeAudio>) -> Result<(), CommandError> {
+    audio::request(&state, audio::Command::Play)
+        .map_err(cache_error)?
+        .map_err(cache_error)
+}
+
+#[tauri::command]
+fn native_audio_pause(state: tauri::State<'_, audio::NativeAudio>) -> Result<(), CommandError> {
+    state.send(audio::Command::Pause).map_err(cache_error)
+}
+
+#[tauri::command]
+fn native_audio_stop(state: tauri::State<'_, audio::NativeAudio>) -> Result<(), CommandError> {
+    state.send(audio::Command::Stop).map_err(cache_error)
+}
+
+#[tauri::command]
+fn native_audio_seek(
+    state: tauri::State<'_, audio::NativeAudio>,
+    position_sec: f64,
+) -> Result<(), CommandError> {
+    state
+        .send(audio::Command::Seek(position_sec))
+        .map_err(cache_error)
+}
+
+#[tauri::command]
+fn native_audio_set_volume(
+    state: tauri::State<'_, audio::NativeAudio>,
+    volume: f32,
+    muted: bool,
+) -> Result<(), CommandError> {
+    state
+        .send(audio::Command::Volume { volume, muted })
+        .map_err(cache_error)
+}
+
+/**
+ * Playback speed.
+ *
+ * ponytail: this resamples, so it transposes — a song at 1.25x plays a little sharp, where the
+ * `<audio>` element corrected the pitch for free. Rate is a podcast feature in a music app and
+ * defaults to 1, so it buys a time-stretcher's worth of DSP for very few listeners. Add
+ * `signalsmith-stretch` between the decoder and the sink if it turns out to matter.
+ */
+#[tauri::command]
+fn native_audio_set_rate(
+    state: tauri::State<'_, audio::NativeAudio>,
+    rate: f32,
+) -> Result<(), CommandError> {
+    state.send(audio::Command::Rate(rate)).map_err(cache_error)
+}
+
+/// Hands playback to the standby deck, over an equal-power crossfade when `fade_ms` is above
+/// zero and in a single step when it is not. False means nothing was preloaded and the caller
+/// should load normally.
+#[tauri::command]
+fn native_audio_transition(
+    state: tauri::State<'_, audio::NativeAudio>,
+    track_id: String,
+    fade_ms: u64,
+) -> Result<bool, CommandError> {
+    audio::request(&state, |reply| audio::Command::Transition {
+        track_id,
+        fade_ms,
+        reply,
+    })
+    .map_err(cache_error)
+}
+
+#[tauri::command]
+fn native_audio_has_standby(
+    state: tauri::State<'_, audio::NativeAudio>,
+    track_id: String,
+) -> Result<bool, CommandError> {
+    audio::request(&state, |reply| audio::Command::HasStandby { track_id, reply })
+        .map_err(cache_error)
+}
+
+#[tauri::command]
+fn native_audio_drop_standby(
+    state: tauri::State<'_, audio::NativeAudio>,
+) -> Result<(), CommandError> {
+    state.send(audio::Command::DropStandby).map_err(cache_error)
+}
+
 #[tauri::command]
 async fn fetch_youtube_music_audio(video_id: String) -> Result<AudioPayload, CommandError> {
     let started_at = Instant::now();
@@ -3935,6 +4169,12 @@ pub fn run() {
     builder
         .manage(LocalAudioWatcher(Mutex::new(None)))
         .setup(|app| {
+            /*
+             * The audio thread and its output device are not opened here — `NativeAudio` starts
+             * them on the first command. A listener on the IFrame engine should never claim a
+             * handle from the OS mixer for a decoder they will not use.
+             */
+            app.manage(audio::NativeAudio::new(app.handle().clone()));
             // Before the log is initialised, so a first run after the rename still logs to
             // the directory the user's settings were just restored into.
             migrate_legacy_app_data(app.handle());
@@ -4020,6 +4260,16 @@ pub fn run() {
             offline_audio_stats,
             offline_audio_prune,
             fetch_youtube_music_audio,
+            native_audio_load,
+            native_audio_play,
+            native_audio_pause,
+            native_audio_stop,
+            native_audio_seek,
+            native_audio_set_volume,
+            native_audio_set_rate,
+            native_audio_transition,
+            native_audio_has_standby,
+            native_audio_drop_standby,
             proxy_http_request,
             load_youtube_music_cookie,
             sign_in_youtube_music,
@@ -4063,8 +4313,66 @@ mod tests {
         audio_chunk_size, playback_ranges, serialize_cookie_pairs, MediaBuffer, AUDIO_HEAD_CHUNK_BYTES, signed_content_length, store_media_item,
         MediaItem, AUDIO_MIN_CHUNK_BYTES, MEDIA_SERVER_MAX_ITEMS, OFFLINE_CHUNK_BYTES,
     };
+    use super::audio::BufferReader;
     use std::collections::HashMap;
+    use std::io::{Read, Seek, SeekFrom};
     use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+
+    /**
+     * The streaming reader the Rust decoder pulls through.
+     *
+     * This is the one place a mistake is inaudible until it is a corrupted song: ranges land
+     * out of order, so a reader that measured "how much has arrived" rather than "how much has
+     * arrived *from the start*" would happily hand the decoder chunk 1 as though it were chunk
+     * 0 and splice the file together wrong.
+     */
+    #[test]
+    fn buffer_reader_serves_only_the_contiguous_prefix() {
+        let buffer = Arc::new(Mutex::new(MediaBuffer::pending(6, 3)));
+        let mut reader = BufferReader::new(Arc::clone(&buffer));
+
+        // The second range wins the race. Nothing is servable yet regardless: byte 0 is missing.
+        buffer.lock().unwrap().put(1, vec![3, 4]);
+
+        let filling = Arc::clone(&buffer);
+        std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(30));
+            filling.lock().unwrap().put(0, vec![1, 2]);
+        });
+
+        let started_at = std::time::Instant::now();
+        let mut head = [0u8; 2];
+        let read = reader.read(&mut head).unwrap();
+        /*
+         * Two things at once: the bytes are the head, not the chunk that happened to land
+         * first, and getting them took the wait. A reader that returned 0 here would look like
+         * the end of the stream to the decoder, and one that returned `[3, 4]` would play the
+         * middle of the song as its beginning.
+         */
+        assert_eq!(&head[..read], &[1, 2]);
+        assert!(started_at.elapsed() >= Duration::from_millis(25));
+
+        // The prefix is served as one run rather than one chunk at a time — the chunk layout is
+        // the downloader's business, not something the decoder should feel.
+        let mut out = [0u8; 8];
+        let read = reader.read(&mut out).unwrap();
+        assert_eq!(&out[..read], &[3, 4]);
+
+        /*
+         * The tail never arrives and the download gives up. EOF, not an error and not a hang:
+         * the decoder finishes the frames it has and the track reports its end, so the queue
+         * advances instead of stalling on a deck that will never empty.
+         */
+        buffer.lock().unwrap().failed = true;
+        assert_eq!(reader.read(&mut out).unwrap(), 0);
+
+        // Symphonia probes containers by seeking around; past the end must clamp rather than
+        // fail, or a probe of a body still downloading kills the load.
+        assert_eq!(reader.seek(SeekFrom::End(0)).unwrap(), 6);
+        assert_eq!(reader.seek(SeekFrom::Start(999)).unwrap(), 6);
+        assert_eq!(reader.seek(SeekFrom::Start(2)).unwrap(), 2);
+    }
 
     /// The head decides how long a click waits for sound, and the two ranges must tile the
     /// body exactly — a gap here is a hole in the audio.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2446,6 +2446,19 @@ const OFFLINE_CHUNK_BYTES: u64 = 4 * 1024 * 1024;
 /// modest so a download does not starve playback of the same connection.
 const OFFLINE_CHUNK_CONCURRENCY: usize = 6;
 
+/**
+ * One playback fill at a time, process-wide.
+ *
+ * Not a rate limit — a correctness guard. googlevideo answers 403 on the later of two range
+ * requests that overlap on one session, so two tracks filling at once means the one being
+ * listened to loses its tail. See `fill_media_buffer`, which holds this for its whole run.
+ *
+ * Downloads (`fetch_audio_ranged`) deliberately stay outside it: they fan out six ways on
+ * purpose, they are a user-initiated bulk action rather than something a listener is waiting
+ * on, and that path has not shown this failure.
+ */
+static PLAYBACK_FILL_LOCK: tokio::sync::Semaphore = tokio::sync::Semaphore::const_new(1);
+
 /** Attempts per playback range before falling back. A 403 here is usually transient. */
 const PLAYBACK_RANGE_ATTEMPTS: usize = 3;
 /** Delay before retrying a refused range; doubled on each further attempt. */
@@ -3062,6 +3075,22 @@ async fn fill_media_buffer(
             guard.failed = true;
         }
     };
+
+    /*
+     * Held for the whole fill, both ranges and the fallback.
+     *
+     * `playback_ranges` removed the fan-out *within* a track after googlevideo was found to
+     * refuse ranges whenever several are in flight on one session — always the later ones,
+     * never the first. What it could not fix from where it sat is the fan-out *across* tracks:
+     * `warmNextTrack` starts the next track's fill the moment the current one loads, so two
+     * fills raced roughly 15 ms apart and the playing track's tail range came back 403. The
+     * whole-file fallback, issued while the other fill was still going, was refused in turn,
+     * and the track died.
+     *
+     * The warmed track waits, which is the right way round: it is an optimisation, and the one
+     * making sound is not.
+     */
+    let _fill_permit = PLAYBACK_FILL_LOCK.acquire().await;
 
     let Ok(request_url) = url::Url::parse(&url) else {
         fail(&buffer);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3212,19 +3212,30 @@ async fn fill_media_buffer(
  * resolves a source into something readable and forwards the request.
  * ---------------------------------------------------------------------------------------- */
 
-/// Where a track's bytes come from. The three cases the player actually has.
+/**
+ * Where a track's bytes come from. The three cases the player actually has.
+ *
+ * Each variant carries its **own** `rename_all`. The container attribute renames the *variants*
+ * — which is what matches `kind: "stream"` — and does nothing at all to the fields inside them,
+ * so with only the outer one this asked the frontend for `mime_type` and rejected every load
+ * with "missing field `mime_type`". `rename_all_fields` would also work; this spells it out per
+ * variant so a serde downgrade cannot quietly take it away again.
+ */
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase", tag = "kind")]
 enum NativeAudioSource {
     /// A signed googlevideo URL, decoded as it downloads.
+    #[serde(rename_all = "camelCase")]
     Stream {
         url: String,
         mime_type: String,
         cookie: Option<String>,
     },
     /// A track already in the offline store.
+    #[serde(rename_all = "camelCase")]
     Offline { track_id: String },
     /// A file the user pointed at a music folder.
+    #[serde(rename_all = "camelCase")]
     File { path: String },
 }
 
@@ -4382,10 +4393,63 @@ mod tests {
         MediaItem, AUDIO_MIN_CHUNK_BYTES, MEDIA_SERVER_MAX_ITEMS, OFFLINE_CHUNK_BYTES,
     };
     use super::audio::BufferReader;
+    use super::NativeAudioSource;
     use std::collections::HashMap;
     use std::io::{Read, Seek, SeekFrom};
     use std::sync::{Arc, Mutex};
     use std::time::Duration;
+
+    /**
+     * The exact JSON `rustAudio.ts` puts on the wire.
+     *
+     * A cross-language boundary that neither `tsc` nor `cargo` can see across: TypeScript sends
+     * `mimeType`, and `#[serde(rename_all)]` on an *enum* renames its variants and not their
+     * fields, so every load was rejected with "missing field `mime_type`" while both sides
+     * compiled and every other check passed. The payloads below are copied from the invoke
+     * calls; keep them that way.
+     */
+    #[test]
+    fn native_audio_source_parses_what_the_frontend_sends() {
+        let stream = serde_json::from_str::<NativeAudioSource>(
+            r#"{"kind":"stream","url":"https://r1.googlevideo.com/videoplayback?clen=99","mimeType":"audio/webm; codecs=\"opus\"","cookie":"SAPISID=x"}"#,
+        )
+        .expect("stream source");
+        match stream {
+            NativeAudioSource::Stream { url, mime_type, cookie } => {
+                assert!(url.contains("googlevideo"));
+                assert_eq!(mime_type, "audio/webm; codecs=\"opus\"");
+                assert_eq!(cookie.as_deref(), Some("SAPISID=x"));
+            }
+            _ => panic!("kind did not select the stream variant"),
+        }
+
+        // The cookie is absent when the session is signed out, and absent must not mean invalid.
+        let anonymous = serde_json::from_str::<NativeAudioSource>(
+            r#"{"kind":"stream","url":"https://r1.googlevideo.com/videoplayback","mimeType":"audio/mp4"}"#,
+        );
+        assert!(anonymous.is_ok(), "a missing cookie is a signed-out session, not an error");
+
+        let offline = serde_json::from_str::<NativeAudioSource>(
+            r#"{"kind":"offline","trackId":"dQw4w9WgXcQ"}"#,
+        )
+        .expect("offline source");
+        assert!(matches!(offline, NativeAudioSource::Offline { track_id } if track_id == "dQw4w9WgXcQ"));
+
+        let file = serde_json::from_str::<NativeAudioSource>(
+            r#"{"kind":"file","path":"C:\\Music\\song.flac"}"#,
+        )
+        .expect("file source");
+        assert!(matches!(file, NativeAudioSource::File { path } if path.ends_with("song.flac")));
+
+        // snake_case is what the bug accepted; it must not be what the contract accepts.
+        assert!(
+            serde_json::from_str::<NativeAudioSource>(
+                r#"{"kind":"stream","url":"https://x/y","mime_type":"audio/mp4"}"#,
+            )
+            .is_err(),
+            "the wire format is camelCase and only camelCase",
+        );
+    }
 
     /**
      * The streaming reader the Rust decoder pulls through.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -44,6 +44,7 @@ mod windows_media;
 
 mod audio;
 mod discord_rpc;
+mod equalizer;
 mod opus_source;
 mod lastfm;
 
@@ -3406,7 +3407,6 @@ async fn native_audio_load(
     let started_at = Instant::now();
 
     let decoded = tauri::async_runtime::spawn_blocking(move || {
-        use rodio::Source as _;
         /*
          * Opus goes to libopus, everything else to rodio.
          *
@@ -3416,16 +3416,10 @@ async fn native_audio_load(
          * most of playback rather than an edge case.
          */
         if opus_source::is_opus(&mime_type) {
-            return opus_source::OpusSource::new(reader, &mime_type).map(|source| {
-                let duration = source.total_duration().map(|value| value.as_secs_f64());
-                (Box::new(source) as audio::BoxedSource, duration)
-            });
+            return opus_source::OpusSource::new(reader, &mime_type).map(equalized);
         }
         rodio::Decoder::new(reader)
-            .map(|decoder| {
-                let duration = decoder.total_duration().map(|value| value.as_secs_f64());
-                (Box::new(decoder) as audio::BoxedSource, duration)
-            })
+            .map(equalized)
             .map_err(|error| format!("audio decode failed: {error}"))
     })
     .await
@@ -3472,6 +3466,43 @@ async fn native_audio_load(
         started_at.elapsed().as_millis()
     );
     Ok(duration)
+}
+
+/**
+ * Puts the equaliser and a limiter between a decoded stream and its deck.
+ *
+ * The limiter is not decoration. Ten bands boosted 12 dB is far more headroom than a normalised
+ * track has, and without it the sum clips into distortion that sounds like a broken decoder
+ * rather than like an equaliser set too high. rodio ships one, so this is a line.
+ *
+ * The duration is read *before* wrapping: it is what the caller reports back to the frontend,
+ * and reading it through two adapters is one more place for it to go missing.
+ */
+fn equalized<S>(source: S) -> (audio::BoxedSource, Option<f64>)
+where
+    S: rodio::Source + Send + 'static,
+{
+    use rodio::Source as _;
+    let duration = source.total_duration().map(|value| value.as_secs_f64());
+    let shaped = equalizer::EqualizedSource::new(source).limit(rodio::source::LimitSettings::new());
+    (Box::new(shaped) as audio::BoxedSource, duration)
+}
+
+/// The ten band gains and the preamp, in dB. Applies to whatever is playing, immediately.
+#[tauri::command]
+fn native_audio_set_equalizer(preamp_db: f32, bands_db: Vec<f32>) -> Result<(), CommandError> {
+    if bands_db.len() != equalizer::BAND_COUNT {
+        return Err(cache_error(format!(
+            "equaliser expects {} bands, got {}",
+            equalizer::BAND_COUNT,
+            bands_db.len()
+        )));
+    }
+    let mut values =
+        equalizer::EqualizerValues { preamp_db, bands_db: [0.0; equalizer::BAND_COUNT] };
+    values.bands_db.copy_from_slice(&bands_db);
+    equalizer::set_values(values);
+    Ok(())
 }
 
 #[tauri::command]
@@ -4463,6 +4494,7 @@ pub fn run() {
             native_audio_transition,
             native_audio_has_standby,
             native_audio_drop_standby,
+            native_audio_set_equalizer,
             media_server_release,
             proxy_http_request,
             load_youtube_music_cookie,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2154,6 +2154,44 @@ fn media_server() -> Result<&'static MediaServer, CommandError> {
     })
 }
 
+/**
+ * Drops every audio body the media server is holding.
+ *
+ * What it costs to leave running is the map, not the socket: up to `MEDIA_SERVER_MAX_ITEMS`
+ * whole songs, megabytes each, kept resident so an `<audio>` element can re-request a range.
+ * The Rust engine reads through `MediaBuffer` in-process and never asks the server for
+ * anything, so once it takes over those bodies are unreachable as well as unused.
+ *
+ * ponytail: the listener thread and its loopback port stay. Reclaiming them means turning the
+ * `OnceLock` into a lock that can be emptied and teaching the accept loop to stop, and the
+ * server would then have to be able to *restart* — the other two engines still need it. One
+ * thread parked in `accept()` is not worth that; the megabytes were the point.
+ *
+ * Returns how many entries were dropped. Zero is the ordinary answer: in `rust` mode from a
+ * cold start `media_server()` is never called, so there is nothing to release.
+ */
+#[tauri::command]
+fn media_server_release() -> Result<usize, CommandError> {
+    let Some(server) = MEDIA_SERVER.get() else {
+        return Ok(0);
+    };
+    let mut items = server.items.lock().map_err(|_| CommandError {
+        message: "media server cache lock poisoned".into(),
+    })?;
+
+    let released = items.len();
+    if released > 0 {
+        /*
+         * Safe against a request already in flight: `handle_media_request` clones the `Arc`
+         * before it reads, so a range being served finishes against the bytes it started with
+         * rather than finding an empty map.
+         */
+        items.clear();
+        eprintln!("[internal][tauri][info] media_server_release entries={released}");
+    }
+    Ok(released)
+}
+
 fn handle_media_request(
     mut stream: std::net::TcpStream,
     items: Arc<Mutex<HashMap<String, MediaItem>>>,
@@ -4270,6 +4308,7 @@ pub fn run() {
             native_audio_transition,
             native_audio_has_standby,
             native_audio_drop_standby,
+            media_server_release,
             proxy_http_request,
             load_youtube_music_cookie,
             sign_in_youtube_music,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -44,6 +44,7 @@ mod windows_media;
 
 mod audio;
 mod discord_rpc;
+mod opus_source;
 mod lastfm;
 
 // Keep the legacy service name so existing sign-in credentials survive the product rename.
@@ -3255,7 +3256,7 @@ enum NativeAudioSource {
     },
     /// A track already in the offline store.
     #[serde(rename_all = "camelCase")]
-    Offline { track_id: String },
+    Offline { track_id: String, mime_type: String },
     /// A file the user pointed at a music folder.
     #[serde(rename_all = "camelCase")]
     File { path: String },
@@ -3294,20 +3295,21 @@ fn open_native_audio_reader(
                 url,
                 track_id.to_string(),
                 cookie,
-                mime_type,
+                mime_type.clone(),
                 Arc::clone(&buffer),
                 ranges,
             ));
             Ok(NativeAudioReader {
                 reader: Box::new(audio::BufferReader::new(Arc::clone(&buffer))),
+                mime_type,
                 buffer: Some(buffer),
             })
         }
-        NativeAudioSource::Offline { track_id } => {
+        NativeAudioSource::Offline { track_id, mime_type } => {
             let path = offline_entry_path(app, &track_id)?;
             let file = File::open(&path)
                 .map_err(|error| cache_error(format!("offline read failed: {error}")))?;
-            Ok(NativeAudioReader { reader: Box::new(file), buffer: None })
+            Ok(NativeAudioReader { reader: Box::new(file), mime_type, buffer: None })
         }
         NativeAudioSource::File { path } => {
             let path = PathBuf::from(path);
@@ -3316,9 +3318,12 @@ fn open_native_audio_reader(
             if !path.is_file() || !is_local_audio_file(&path) {
                 return Err(cache_error("local audio file is unavailable."));
             }
+            // The extension is the only codec hint a local file carries; the same mapping
+            // `local_audio_read` hands the webview.
+            let mime_type = local_audio_mime_type(&path).to_string();
             let file = File::open(&path)
                 .map_err(|error| cache_error(format!("local audio read failed: {error}")))?;
-            Ok(NativeAudioReader { reader: Box::new(file), buffer: None })
+            Ok(NativeAudioReader { reader: Box::new(file), mime_type, buffer: None })
         }
     }
 }
@@ -3331,14 +3336,15 @@ fn open_native_audio_reader(
  * `PLAYBACK_FILL_LOCK` while doing it, so every refusal delayed the next real load.
  */
 struct NativeAudioReader {
-    reader: Box<dyn NativeAudioRead>,
+    /// `MediaSource` is `Read + Seek + Send + Sync` plus a length — exactly what symphonia's
+    /// probe needs and a superset of what rodio's decoder does, so one box serves both.
+    reader: Box<dyn symphonia::core::io::MediaSource>,
+    /// The declared codec, which is what decides *which* decoder gets the box.
+    mime_type: String,
     buffer: Option<Arc<Mutex<MediaBuffer>>>,
 }
 
-/// What rodio's decoder needs of a byte source. Named so the three cases above can be boxed
-/// into one type.
-trait NativeAudioRead: Read + std::io::Seek + Send + Sync {}
-impl<T: Read + std::io::Seek + Send + Sync> NativeAudioRead for T {}
+
 
 /**
  * Decodes a track onto a deck.
@@ -3360,11 +3366,26 @@ async fn native_audio_load(
     duration_sec: Option<f64>,
     standby: Option<bool>,
 ) -> Result<f64, CommandError> {
-    let NativeAudioReader { reader, buffer } = open_native_audio_reader(&app, &track_id, source)?;
+    let NativeAudioReader { reader, mime_type, buffer } =
+        open_native_audio_reader(&app, &track_id, source)?;
     let started_at = Instant::now();
 
     let decoded = tauri::async_runtime::spawn_blocking(move || {
         use rodio::Source as _;
+        /*
+         * Opus goes to libopus, everything else to rodio.
+         *
+         * Not a preference — symphonia has no Opus decoder at all, and rodio can only offer
+         * what symphonia implements. WebM/Opus is the majority of what YouTube serves at
+         * `high`, and the only audio offered for a large share of tracks, so this branch is
+         * most of playback rather than an edge case.
+         */
+        if opus_source::is_opus(&mime_type) {
+            return opus_source::OpusSource::new(reader, &mime_type).map(|source| {
+                let duration = source.total_duration().map(|value| value.as_secs_f64());
+                (Box::new(source) as audio::BoxedSource, duration)
+            });
+        }
         rodio::Decoder::new(reader)
             .map(|decoder| {
                 let duration = decoder.total_duration().map(|value| value.as_secs_f64());
@@ -4459,6 +4480,32 @@ mod tests {
     use std::time::Duration;
 
     /**
+     * Which decoder a track is sent to.
+     *
+     * The consequence of getting this wrong is not a fallback, it is a failed load: rodio
+     * cannot decode Opus at all, and libopus cannot read anything else. The `audio/mp4` case is
+     * the one that already worked when every WebM track was failing, so it is the one that must
+     * not start being routed to libopus.
+     */
+    #[test]
+    fn opus_routing_follows_the_declared_codec() {
+        use super::opus_source::is_opus;
+
+        // What YouTube actually serves at `high` — 13 of 14 resolves in the log that found this.
+        assert!(is_opus(r#"audio/webm; codecs="opus""#));
+        assert!(is_opus("audio/opus"), "a local .opus file");
+        assert!(is_opus("audio/webm"), "WebM carries no other audio codec worth guessing");
+        assert!(is_opus("AUDIO/WEBM; CODECS=\"OPUS\""), "the header case is not ours to assume");
+
+        assert!(!is_opus(r#"audio/mp4; codecs="mp4a.40.2""#), "AAC is rodio's");
+        assert!(!is_opus("audio/flac"));
+        assert!(!is_opus("audio/mpeg"));
+        // Ogg is Vorbis far more often than Opus, and rodio has a Vorbis decoder. An Opus
+        // stream in an `.ogg` wrapper is the one shape this deliberately misroutes.
+        assert!(!is_opus("audio/ogg"));
+    }
+
+    /**
      * The exact JSON `rustAudio.ts` puts on the wire.
      *
      * A cross-language boundary that neither `tsc` nor `cargo` can see across: TypeScript sends
@@ -4489,10 +4536,18 @@ mod tests {
         assert!(anonymous.is_ok(), "a missing cookie is a signed-out session, not an error");
 
         let offline = serde_json::from_str::<NativeAudioSource>(
-            r#"{"kind":"offline","trackId":"dQw4w9WgXcQ"}"#,
+            r#"{"kind":"offline","trackId":"dQw4w9WgXcQ","mimeType":"audio/webm; codecs=\"opus\""}"#,
         )
         .expect("offline source");
-        assert!(matches!(offline, NativeAudioSource::Offline { track_id } if track_id == "dQw4w9WgXcQ"));
+        // The mime type rides along because a downloaded body has no extension to read it from,
+        // and it is what decides whether libopus or rodio gets the file.
+        match offline {
+            NativeAudioSource::Offline { track_id, mime_type } => {
+                assert_eq!(track_id, "dQw4w9WgXcQ");
+                assert!(super::opus_source::is_opus(&mime_type));
+            }
+            _ => panic!("kind did not select the offline variant"),
+        }
 
         let file = serde_json::from_str::<NativeAudioSource>(
             r#"{"kind":"file","path":"C:\\Music\\song.flac"}"#,

--- a/src-tauri/src/opus_source.rs
+++ b/src-tauri/src/opus_source.rs
@@ -1,0 +1,257 @@
+/*!
+ * Opus playback: symphonia demuxes, libopus decodes.
+ *
+ * symphonia has no Opus decoder — not a missing feature flag, the codec is simply absent from
+ * 0.5 — and YouTube serves Opus-in-WebM for the large majority of tracks at `high` quality, and
+ * as the *only* audio offered for many of them. So the container is read with symphonia, which
+ * already handles Matroska and Ogg, and the packets inside go to libopus.
+ *
+ * Everything else — AAC, FLAC, MP3, ALAC, Vorbis, WAV — stays on `rodio::Decoder`, which does
+ * have decoders for those. This module exists for exactly one codec.
+ */
+
+use std::collections::VecDeque;
+use std::time::Duration;
+
+use rodio::{ChannelCount, SampleRate, Source};
+use symphonia::core::codecs::CODEC_TYPE_OPUS;
+use symphonia::core::errors::Error as SymphoniaError;
+use symphonia::core::formats::{FormatOptions, FormatReader, SeekMode, SeekTo};
+use symphonia::core::io::{MediaSource, MediaSourceStream};
+use symphonia::core::meta::MetadataOptions;
+use symphonia::core::probe::Hint;
+use symphonia::core::units::Time;
+
+/// Opus always decodes at 48 kHz, whatever the source was encoded from. Fixed by RFC 6716.
+const OPUS_SAMPLE_RATE: u32 = 48_000;
+
+/// Longest Opus frame is 120 ms, which at 48 kHz is 5760 samples per channel.
+const MAX_FRAME_SAMPLES: usize = 5_760;
+
+/// Whether a mime type names something only libopus can decode.
+pub(crate) fn is_opus(mime_type: &str) -> bool {
+    let lowered = mime_type.to_ascii_lowercase();
+    /*
+     * `audio/webm` on its own counts. YouTube labels the Opus tier
+     * `audio/webm; codecs="opus"`, but a truncated or generic label still means Opus in
+     * practice — WebM carries no other audio codec that symphonia would want instead, and
+     * guessing wrong here costs one failed load rather than silence.
+     */
+    lowered.contains("opus") || lowered.contains("webm")
+}
+
+pub(crate) struct OpusSource {
+    format: Box<dyn FormatReader>,
+    decoder: opus::Decoder,
+    track_id: u32,
+    channels: ChannelCount,
+    /// Decoded samples not yet handed to rodio, interleaved.
+    pending: VecDeque<f32>,
+    /// Reused across packets so decoding does not allocate per frame.
+    scratch: Vec<f32>,
+    total_duration: Option<Duration>,
+    /// Samples the encoder asks to be thrown away — the codec's own warm-up, not audio.
+    skip_samples: usize,
+    exhausted: bool,
+}
+
+impl OpusSource {
+    /**
+     * Opens a reader as an Opus stream.
+     *
+     * Fails when the container holds no Opus track, which is the caller's cue that this was the
+     * wrong path and rodio should have it instead.
+     */
+    pub(crate) fn new(
+        source: Box<dyn MediaSource>,
+        mime_type: &str,
+    ) -> Result<Self, String> {
+        let stream = MediaSourceStream::new(source, Default::default());
+
+        let mut hint = Hint::new();
+        // Helps the probe pick a reader without sniffing the whole header. Harmless when wrong:
+        // the probe falls back to content detection.
+        if mime_type.contains("webm") || mime_type.contains("matroska") {
+            hint.with_extension("webm");
+        } else if mime_type.contains("ogg") || mime_type.contains("opus") {
+            hint.with_extension("ogg");
+        }
+
+        let probed = symphonia::default::get_probe()
+            .format(
+                &hint,
+                stream,
+                &FormatOptions { enable_gapless: true, ..Default::default() },
+                &MetadataOptions::default(),
+            )
+            .map_err(|error| format!("opus container probe failed: {error}"))?;
+        let format = probed.format;
+
+        let track = format
+            .tracks()
+            .iter()
+            .find(|track| track.codec_params.codec == CODEC_TYPE_OPUS)
+            .ok_or_else(|| "container holds no Opus track".to_string())?;
+
+        let params = &track.codec_params;
+        let track_id = track.id;
+        let channel_count = params.channels.map(|channels| channels.count()).unwrap_or(2).max(1);
+        let channels = ChannelCount::new(channel_count as u16)
+            .ok_or_else(|| "opus track declared zero channels".to_string())?;
+
+        let opus_channels = match channel_count {
+            1 => opus::Channels::Mono,
+            2 => opus::Channels::Stereo,
+            /*
+             * libopus decodes only mono and stereo through this API; surround needs the
+             * multistream decoder. YouTube Music does not serve surround, so this reports
+             * rather than pretending.
+             */
+            other => return Err(format!("unsupported opus channel count: {other}")),
+        };
+        let decoder = opus::Decoder::new(OPUS_SAMPLE_RATE, opus_channels)
+            .map_err(|error| format!("opus decoder init failed: {error}"))?;
+
+        /*
+         * Duration from the container's own frame count rather than from the file size — an
+         * Opus stream is variable bitrate, so bytes say nothing useful about length.
+         */
+        let total_duration = params.n_frames.map(|frames| {
+            Duration::from_secs_f64(frames as f64 / OPUS_SAMPLE_RATE as f64)
+        });
+
+        /*
+         * Pre-skip. Every Opus stream begins with encoder warm-up that is not part of the
+         * recording; OpusHead states how much, and playing it back is an audible tick at the
+         * start of every single track.
+         */
+        let skip_samples = params.delay.unwrap_or(0) as usize * channel_count;
+
+        Ok(Self {
+            format,
+            decoder,
+            track_id,
+            channels,
+            pending: VecDeque::with_capacity(MAX_FRAME_SAMPLES * channel_count),
+            scratch: vec![0.0; MAX_FRAME_SAMPLES * channel_count],
+            total_duration,
+            skip_samples,
+            exhausted: false,
+        })
+    }
+
+    /// Decodes the next packet belonging to our track. False means the stream ended.
+    fn fill(&mut self) -> bool {
+        while !self.exhausted {
+            let packet = match self.format.next_packet() {
+                Ok(packet) => packet,
+                Err(SymphoniaError::IoError(error))
+                    if error.kind() == std::io::ErrorKind::UnexpectedEof =>
+                {
+                    self.exhausted = true;
+                    return false;
+                }
+                Err(error) => {
+                    eprintln!("[internal][tauri][warn] opus demux ended: {error}");
+                    self.exhausted = true;
+                    return false;
+                }
+            };
+            // A WebM file interleaves streams; packets for the video track are not ours.
+            if packet.track_id() != self.track_id {
+                continue;
+            }
+
+            let frames = match self.decoder.decode_float(&packet.data, &mut self.scratch, false) {
+                Ok(frames) => frames,
+                Err(error) => {
+                    /*
+                     * One bad packet is not a dead track — a range that arrived torn will
+                     * produce one, and dropping it costs a few milliseconds of audio where
+                     * giving up costs the song.
+                     */
+                    eprintln!("[internal][tauri][warn] opus packet dropped: {error}");
+                    continue;
+                }
+            };
+
+            let sample_count = frames * self.channels.get() as usize;
+            let mut decoded = &self.scratch[..sample_count.min(self.scratch.len())];
+            if self.skip_samples > 0 {
+                let skipped = self.skip_samples.min(decoded.len());
+                self.skip_samples -= skipped;
+                decoded = &decoded[skipped..];
+            }
+            if decoded.is_empty() {
+                continue;
+            }
+            self.pending.extend(decoded.iter().copied());
+            return true;
+        }
+        false
+    }
+}
+
+impl Iterator for OpusSource {
+    type Item = f32;
+
+    #[inline]
+    fn next(&mut self) -> Option<f32> {
+        if let Some(sample) = self.pending.pop_front() {
+            return Some(sample);
+        }
+        if !self.fill() {
+            return None;
+        }
+        self.pending.pop_front()
+    }
+}
+
+impl Source for OpusSource {
+    #[inline]
+    fn current_span_len(&self) -> Option<usize> {
+        // Channel count and sample rate never change mid-stream for Opus, so there is only ever
+        // one span and its end is the end of the track.
+        None
+    }
+
+    #[inline]
+    fn channels(&self) -> ChannelCount {
+        self.channels
+    }
+
+    #[inline]
+    fn sample_rate(&self) -> SampleRate {
+        SampleRate::new(OPUS_SAMPLE_RATE).expect("48 kHz is not zero")
+    }
+
+    #[inline]
+    fn total_duration(&self) -> Option<Duration> {
+        self.total_duration
+    }
+
+    fn try_seek(&mut self, position: Duration) -> Result<(), rodio::source::SeekError> {
+        self.format
+            .seek(
+                SeekMode::Coarse,
+                SeekTo::Time {
+                    time: Time::from(position.as_secs_f64()),
+                    track_id: Some(self.track_id),
+                },
+            )
+            .map_err(|error| {
+                eprintln!("[internal][tauri][warn] opus seek failed: {error}");
+                rodio::source::SeekError::NotSupported { underlying_source: "OpusSource" }
+            })?;
+
+        /*
+         * Everything decoded before the seek belongs to where the track *was*. The decoder also
+         * has to forget its inter-frame state, or the first frames after a jump are reconstructed
+         * against samples from somewhere else entirely and arrive as a burst of noise.
+         */
+        self.pending.clear();
+        self.exhausted = false;
+        let _ = self.decoder.reset_state();
+        Ok(())
+    }
+}

--- a/src-tauri/src/opus_source.rs
+++ b/src-tauri/src/opus_source.rs
@@ -40,6 +40,30 @@ pub(crate) fn is_opus(mime_type: &str) -> bool {
     lowered.contains("opus") || lowered.contains("webm")
 }
 
+/**
+ * How long the track is, according to the container.
+ *
+ * `n_frames` is a count in whatever unit the container keeps time in — Matroska's default is
+ * milliseconds, Ogg's is samples — so it only means anything through the track's own time base.
+ * Dividing it by the sample rate instead came out 48× short against WebM, which read as a
+ * three-second song: with crossfade on, `remaining` was inside the fade window from the first
+ * tick and the queue raced through fifteen tracks in twenty seconds.
+ *
+ * `None` means the container did not say, and the caller falls back to the duration the provider
+ * already reported for the track.
+ */
+fn container_duration(
+    time_base: Option<symphonia::core::units::TimeBase>,
+    n_frames: Option<u64>,
+) -> Option<Duration> {
+    let (time_base, frames) = (time_base?, n_frames?);
+    if time_base.numer == 0 || time_base.denom == 0 {
+        return None;
+    }
+    let time = time_base.calc_time(frames);
+    Some(Duration::from_secs_f64(time.seconds as f64 + time.frac))
+}
+
 pub(crate) struct OpusSource {
     format: Box<dyn FormatReader>,
     decoder: opus::Decoder,
@@ -112,13 +136,7 @@ impl OpusSource {
         let decoder = opus::Decoder::new(OPUS_SAMPLE_RATE, opus_channels)
             .map_err(|error| format!("opus decoder init failed: {error}"))?;
 
-        /*
-         * Duration from the container's own frame count rather than from the file size — an
-         * Opus stream is variable bitrate, so bytes say nothing useful about length.
-         */
-        let total_duration = params.n_frames.map(|frames| {
-            Duration::from_secs_f64(frames as f64 / OPUS_SAMPLE_RATE as f64)
-        });
+        let total_duration = container_duration(params.time_base, params.n_frames);
 
         /*
          * Pre-skip. Every Opus stream begins with encoder warm-up that is not part of the
@@ -253,5 +271,48 @@ impl Source for OpusSource {
         self.exhausted = false;
         let _ = self.decoder.reset_state();
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::container_duration;
+    use symphonia::core::units::TimeBase;
+
+    /**
+     * A duration read through the container's time base, not by dividing by the sample rate.
+     *
+     * The numbers are the real ones from the failure: a track that reported 4.251 s was
+     * 204,061 ms of Matroska. With crossfade at 9 s that put `remaining` inside the fade window
+     * from the first tick, so every track handed straight over to the next and the queue burned
+     * through fifteen songs in twenty seconds.
+     */
+    #[test]
+    fn duration_is_read_through_the_containers_time_base() {
+        // Matroska's default timecode scale: milliseconds.
+        let mkv = container_duration(TimeBase::new(1, 1_000).into(), Some(204_061))
+            .expect("mkv duration");
+        assert!(
+            (mkv.as_secs_f64() - 204.061).abs() < 0.01,
+            "3:24 of Matroska, not the 4.25 s that dividing by 48000 produced: {mkv:?}",
+        );
+
+        // Ogg keeps time in samples, where dividing by the rate happens to be right — the point
+        // is that one formula covers both because it asks the container.
+        let ogg = container_duration(TimeBase::new(1, 48_000).into(), Some(9_794_928))
+            .expect("ogg duration");
+        assert!(
+            (ogg.as_secs_f64() - 204.06).abs() < 0.01,
+            "the same track in Ogg is the same length: {ogg:?}",
+        );
+
+        // Unknown stays unknown rather than becoming zero, so the caller can fall back to the
+        // duration the provider reported instead of trusting a made-up one.
+        assert!(container_duration(None, Some(204_061)).is_none());
+        assert!(container_duration(TimeBase::new(1, 1_000).into(), None).is_none());
+        assert!(
+            container_duration(Some(TimeBase { numer: 0, denom: 0 }), Some(204_061)).is_none(),
+            "a degenerate time base is unknown, not a panic — calc_time asserts on it",
+        );
     }
 }

--- a/src-tauri/src/opus_source.rs
+++ b/src-tauri/src/opus_source.rs
@@ -41,6 +41,61 @@ pub(crate) fn is_opus(mime_type: &str) -> bool {
 }
 
 /**
+ * The container a stored body actually is, read from its own first bytes.
+ *
+ * For anything already on disk the declared mime type is not evidence. `Track.mimeType`
+ * describes what was resolved for *streaming*, and a row that came from a playlist listing
+ * carries none at all — so a downloaded track falls back to `audio/mp4` while the bytes on disk
+ * are very often Opus in WebM. That misroute sent the file to rodio, which parsed the Matroska
+ * fine and then had no Opus decoder to hand the packets to: "the format of the data has not been
+ * recognized", for a track that had downloaded perfectly.
+ *
+ * Rewinds before returning, so the caller hands the decoder a reader at the start.
+ * `None` means the bytes look like nothing recognised and the declared type is as good a guess
+ * as any.
+ */
+pub(crate) fn sniff_container_mime(
+    reader: &mut (impl std::io::Read + std::io::Seek),
+) -> std::io::Result<Option<&'static str>> {
+    let mut header = [0u8; 64];
+    let mut filled = 0;
+    while filled < header.len() {
+        match reader.read(&mut header[filled..]) {
+            Ok(0) => break,
+            Ok(read) => filled += read,
+            Err(error) if error.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(error) => return Err(error),
+        }
+    }
+    reader.seek(std::io::SeekFrom::Start(0))?;
+    Ok(container_mime_of(&header[..filled]))
+}
+
+/// The magic-number half of `sniff_container_mime`, split out so it can be tested on bytes.
+fn container_mime_of(header: &[u8]) -> Option<&'static str> {
+    if header.starts_with(&[0x1A, 0x45, 0xDF, 0xA3]) {
+        // Matroska. YouTube's WebM audio is always Opus, and a WebM carrying Vorbis instead is
+        // rare enough that failing loudly on it beats guessing the other way on every download.
+        return Some("audio/webm; codecs=\"opus\"");
+    }
+    if header.starts_with(b"OggS") {
+        // Ogg carries either, and only the codec header inside the first page says which.
+        return Some(if header.windows(8).any(|window| window == b"OpusHead") {
+            "audio/opus"
+        } else {
+            "audio/ogg"
+        });
+    }
+    if header.len() >= 12 && &header[4..8] == b"ftyp" {
+        return Some("audio/mp4");
+    }
+    if header.starts_with(b"fLaC") {
+        return Some("audio/flac");
+    }
+    None
+}
+
+/**
  * How long the track is, according to the container.
  *
  * `n_frames` is a count in whatever unit the container keeps time in — Matroska's default is
@@ -276,8 +331,70 @@ impl Source for OpusSource {
 
 #[cfg(test)]
 mod tests {
-    use super::container_duration;
+    use super::{container_duration, container_mime_of, is_opus, sniff_container_mime};
     use symphonia::core::units::TimeBase;
+
+    /// Byte literals spelled as numbers: the headers here are magic numbers, and writing them
+    /// as escaped strings makes them harder to check against a hex dump, not easier.
+    fn ogg_page(codec_header: &[u8]) -> Vec<u8> {
+        let mut page = b"OggS".to_vec();
+        page.extend_from_slice(&[0x00, 0x02, 0, 0, 0, 0, 0, 0]);
+        page.extend_from_slice(codec_header);
+        page
+    }
+
+    /**
+     * A stored body is routed by its own bytes, not by what something said it was.
+     *
+     * The case that found this: a downloaded track whose file began 1A 45 DF A3 — Matroska
+     * holding Opus — was declared `audio/mp4`, because `Track.mimeType` describes what was
+     * resolved for *streaming* and a row from a playlist listing carries none at all. rodio
+     * parsed the container happily and then had no Opus decoder for what was inside, so a
+     * download that was perfectly intact reported "the format of the data has not been
+     * recognized".
+     */
+    #[test]
+    fn a_stored_container_is_identified_by_its_own_bytes() {
+        let matroska = [0x1A, 0x45, 0xDF, 0xA3, 0x9F, 0x42, 0x86, 0x81];
+        let sniffed = container_mime_of(&matroska).expect("matroska");
+        assert!(is_opus(sniffed), "WebM has to reach libopus whatever it was declared as");
+
+        // Ogg carries either codec; only the header inside the first page distinguishes them.
+        assert!(is_opus(
+            container_mime_of(&ogg_page(b"OpusHead")).expect("ogg opus")
+        ));
+        assert!(
+            !is_opus(container_mime_of(&ogg_page(&[0x01, b'v', b'o', b'r', b'b', b'i', b's']))
+                .expect("ogg vorbis")),
+            "rodio has a Vorbis decoder; libopus does not",
+        );
+
+        // The same mistake in reverse would send AAC to libopus, which cannot read it either.
+        let mut mp4 = vec![0, 0, 0, 0x20];
+        mp4.extend_from_slice(b"ftypM4A ");
+        assert!(!is_opus(container_mime_of(&mp4).expect("mp4")));
+
+        assert_eq!(container_mime_of(b"fLaC____"), Some("audio/flac"));
+        // Nothing recognised leaves the declared type standing rather than inventing one.
+        assert_eq!(container_mime_of(b"not a container at all"), None);
+        assert_eq!(container_mime_of(&[]), None);
+    }
+
+    /// Sniffing must leave the reader at the start, or the decoder gets a headless stream.
+    #[test]
+    fn sniffing_rewinds_the_reader() {
+        let mut body = vec![0x1A, 0x45, 0xDF, 0xA3];
+        body.extend(std::iter::repeat(0xAB).take(200));
+        let mut cursor = std::io::Cursor::new(body);
+
+        let sniffed = sniff_container_mime(&mut cursor).expect("sniff");
+        assert!(is_opus(sniffed.expect("matroska")));
+        assert_eq!(cursor.position(), 0, "the decoder must see the container header");
+
+        // Shorter than the sniff window: a short read is not a failure.
+        let mut tiny = std::io::Cursor::new(vec![0x1A, 0x45, 0xDF, 0xA3]);
+        assert!(sniff_container_mime(&mut tiny).expect("sniff").is_some());
+    }
 
     /**
      * A duration read through the container's time base, not by dividing by the sample rate.

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Zuno",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "identifier": "com.zuno.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/datasource/DataSource.ts
+++ b/src/datasource/DataSource.ts
@@ -12,6 +12,7 @@ import type {
   Lyrics,
   Playlist,
   ResolvedLink,
+  RustAudioSource,
   SearchCategory,
   SearchResults,
   AuthStage,
@@ -38,6 +39,14 @@ export type StreamData = {
   bytes?: ArrayBuffer;
   mimeType?: string;
   sourceUrl?: string;
+  /**
+   * Where the Rust engine should read the bytes from, when that engine is selected.
+   *
+   * Present *instead of* `bytes` and `sourceUrl`, not alongside them: the whole point of the
+   * Rust path is that no audio crosses IPC and nothing is published to the media server, so
+   * resolving one of the other two would do the work this avoids.
+   */
+  rustSource?: RustAudioSource;
 };
 
 export abstract class DataSource {

--- a/src/datasource/types.ts
+++ b/src/datasource/types.ts
@@ -265,5 +265,5 @@ export interface LibrarySnapshot {
  */
 export type RustAudioSource =
   | { kind: "stream"; url: string; mimeType: string; cookie?: string }
-  | { kind: "offline"; trackId: string }
+  | { kind: "offline"; trackId: string; mimeType: string }
   | { kind: "file"; path: string };

--- a/src/datasource/types.ts
+++ b/src/datasource/types.ts
@@ -256,3 +256,14 @@ export interface LibrarySnapshot {
   librarySongs?: Track[];
   recentlyPlayed: Track[];
 }
+
+/**
+ * Where the Rust audio engine should read a track's bytes from.
+ *
+ * Lives here rather than in `player/` because `StreamData` carries it and nothing under
+ * `datasource/` may import upward. Mirrors `NativeAudioSource` in `src-tauri/src/lib.rs`.
+ */
+export type RustAudioSource =
+  | { kind: "stream"; url: string; mimeType: string; cookie?: string }
+  | { kind: "offline"; trackId: string }
+  | { kind: "file"; path: string };

--- a/src/datasource/youtube/YouTubeMusicDataSource.ts
+++ b/src/datasource/youtube/YouTubeMusicDataSource.ts
@@ -51,7 +51,7 @@ import {
   unmetPrecondition,
 } from "./lyricsSources";
 import { getPreferredLyricsSourceId } from "../../internal/lyricsSourcePreference";
-import { looksLikeYouTubeLink, parseYouTubeLink } from "./links";
+import { isVideoId, looksLikeYouTubeLink, parseYouTubeLink } from "./links";
 import { isTrackDownloaded } from "../../player/offlineStore";
 import {
   getDownloadQuality,
@@ -1000,9 +1000,24 @@ export class YouTubeMusicDataSource extends DataSource {
   }
 
   private toTrack(item: MusicItem): Track | null {
-    const id = item.id ?? item.endpoint?.payload?.videoId;
+    /*
+     * The endpoint wins over `item.id`.
+     *
+     * `item.id` is whatever the renderer happened to be keyed on — a video id for a song, a
+     * *browse* id for a show — while `endpoint.payload.videoId` only ever names the thing that
+     * plays. For an ordinary song the two hold the same value, so this changes nothing there;
+     * it changes the rows that were never playable in the first place.
+     */
+    const id = item.endpoint?.payload?.videoId ?? item.id;
     const title = this.getTitle(item);
-    if (!id || !title) return null;
+    /*
+     * A shape check as well as a presence check. An artist page's popular-songs shelf mixes in
+     * podcast shows whose id is `MPSPPL…`; those became tracks, and clicking one walked all
+     * three Innertube clients only to be told "This video is unavailable" by each. Dropping
+     * them here means they never reach a queue — `toTrack` already returns null for unusable
+     * items and every caller filters.
+     */
+    if (!isVideoId(id) || !title) return null;
     const viewCountText = this.getViewCountText(item);
     const album = this.getTrackAlbum(item);
 

--- a/src/datasource/youtube/YouTubeMusicDataSource.ts
+++ b/src/datasource/youtube/YouTubeMusicDataSource.ts
@@ -63,6 +63,7 @@ import {
   usesAuthenticatedStreaming,
   usesYouTubeScrobbling,
 } from "../../ui/settings/youtubeAccount";
+import { usesRustAudioEngine } from "../../ui/settings/audioEngine";
 import {
   getLiveCookie,
   notifyAuthRejected,
@@ -5863,6 +5864,10 @@ export class YouTubeMusicDataSource extends DataSource {
   }
 
   async getStreamData(track: Track): Promise<StreamData> {
+    if (usesRustAudioEngine()) {
+      return this.getRustStreamData(track);
+    }
+
     if (track.source === "local") {
       if (!track.localPath) {
         throw new Error("Local track path is missing.");
@@ -5937,6 +5942,46 @@ export class YouTubeMusicDataSource extends DataSource {
     return {
       mimeType: payload.mimeType,
       sourceUrl: payload.url,
+    };
+  }
+
+  /**
+   * The same three cases as `getStreamData`, resolved to a *reference* rather than to bytes.
+   *
+   * This is what the Rust engine buys before a single sample is decoded. A local file is a path
+   * instead of the whole song base64-encoded across IPC; a download is a track id instead of a
+   * copy loaded into the media server; a stream is the signed URL itself instead of a
+   * `fetch_audio_source` round trip that publishes the body and hands back a loopback URL. In
+   * every case Rust already has, or can get, the bytes — asking the webview to carry them first
+   * was only ever in service of an `<audio>` element that no longer exists on this path.
+   */
+  private async getRustStreamData(track: Track): Promise<StreamData> {
+    if (track.source === "local") {
+      if (!track.localPath) {
+        throw new Error("Local track path is missing.");
+      }
+      return {
+        mimeType: track.mimeType ?? "audio/mp4",
+        rustSource: { kind: "file", path: track.localPath },
+      };
+    }
+
+    if (isTrackDownloaded(track.id)) {
+      return {
+        mimeType: track.mimeType ?? "audio/mp4",
+        rustSource: { kind: "offline", trackId: track.id },
+      };
+    }
+
+    const { url, mimeType, cookie } = await this.resolveStreamUrl(track);
+    logInternalInfo("YouTubeMusicDataSource.getRustStreamData resolved", {
+      trackId: track.id,
+      mimeType,
+      authenticated: Boolean(cookie),
+    });
+    return {
+      mimeType,
+      rustSource: { kind: "stream", url, mimeType, cookie },
     };
   }
 

--- a/src/datasource/youtube/YouTubeMusicDataSource.ts
+++ b/src/datasource/youtube/YouTubeMusicDataSource.ts
@@ -5982,10 +5982,13 @@ export class YouTubeMusicDataSource extends DataSource {
     }
 
     if (isTrackDownloaded(track.id)) {
-      return {
-        mimeType: track.mimeType ?? "audio/mp4",
-        rustSource: { kind: "offline", trackId: track.id },
-      };
+      const mimeType = track.mimeType ?? "audio/mp4";
+      /*
+       * The mime type travels with the id because it is what picks the decoder: a downloaded
+       * body is raw bytes on disk with no extension to read, and Opus needs libopus while
+       * everything else goes to rodio.
+       */
+      return { mimeType, rustSource: { kind: "offline", trackId: track.id, mimeType } };
     }
 
     const { url, mimeType, cookie } = await this.resolveStreamUrl(track);

--- a/src/datasource/youtube/links.check.ts
+++ b/src/datasource/youtube/links.check.ts
@@ -11,7 +11,7 @@
  */
 export {};
 
-import { looksLikeYouTubeLink, parseYouTubeLink } from "./links";
+import { isVideoId, looksLikeYouTubeLink, parseYouTubeLink } from "./links";
 import type { ResolvedLink } from "../types";
 
 function check(condition: boolean, message: string): void {
@@ -112,5 +112,27 @@ check(
   "text that merely mentions youtube is a search, not a link",
 );
 check(!looksLikeYouTubeLink("metro boomin"), "an ordinary query is a search");
+
+/*
+ * What may be treated as something that plays.
+ *
+ * The case that made this necessary: an artist page's popular-songs shelf mixes in podcast
+ * shows, whose id is a browse id rather than a video id. They were turned into tracks, and
+ * clicking one walked all three Innertube clients only to be told "This video is unavailable"
+ * by each — the id had never named a video.
+ */
+check(isVideoId("dQw4w9WgXcQ"), "an ordinary video id");
+check(isVideoId("_lMlsPQJs6U"), "leading underscore is in the alphabet");
+check(isVideoId("SOySR3DJO5Q"), "mixed case is in the alphabet");
+check(
+  !isVideoId("MPSPPLDfKAXSi6kUZChoCmv-rvfdEEfgZTFBzS"),
+  "a show's browse id is not a video id",
+);
+check(!isVideoId("MPREb_9nY3XYZ1234"), "an album browse id is not a video id");
+check(!isVideoId("PLDfKAXSi6kUZChoCmv"), "a playlist id is not a video id");
+check(!isVideoId("tooshort"), "ten characters is not eleven");
+check(!isVideoId("dQw4w9WgXcQ!"), "a character outside the alphabet disqualifies it");
+check(!isVideoId(""), "empty is not an id");
+check(!isVideoId(undefined), "absent is not an id");
 
 console.log("links.check.ts OK");

--- a/src/datasource/youtube/links.ts
+++ b/src/datasource/youtube/links.ts
@@ -79,9 +79,18 @@ function isYouTubeHost(hostname: string): boolean {
     || host === "youtu.be";
 }
 
-/** Video ids are 11 characters of the URL-safe base64 alphabet. */
-function isVideoId(value: string): boolean {
-  return /^[\w-]{11}$/.test(value);
+/**
+ * Video ids are 11 characters of the URL-safe base64 alphabet.
+ *
+ * Exported because it is also what decides whether a shelf row may become a *track*. An artist
+ * page mixes songs with shows, and a show's `id` is a browse id — `MPSP` wrapped around a `PL…`
+ * playlist id, 34 characters. Those were turned into tracks, and every Innertube client answered
+ * "This video is unavailable" when one was clicked, because the id had never named a video.
+ *
+ * Widened to accept a missing value so callers do not each repeat the same null check.
+ */
+export function isVideoId(value: string | null | undefined): value is string {
+  return typeof value === "string" && /^[\w-]{11}$/.test(value);
 }
 
 /**

--- a/src/internal/releaseNote.check.ts
+++ b/src/internal/releaseNote.check.ts
@@ -88,13 +88,36 @@ equal(
   "a body that is nothing but a link has no empty text around it",
 );
 
-// Rejoining every segment must reproduce the original exactly, or the note silently loses text.
-const roundTrip = parseReleaseNote(RELEASE_NOTE_BODY).map((s) => s.value).join("");
+/* Rejoining every segment must reproduce the original exactly, or the note silently loses text.
+   `**` is the one thing deliberately consumed, so it is put back before comparing — everything
+   else, prose and links alike, has to survive verbatim. */
+const roundTrip = parseReleaseNote(RELEASE_NOTE_BODY)
+  .map((s) => (s.kind === "strong" ? `**${s.value}**` : s.value))
+  .join("");
 equal(roundTrip, RELEASE_NOTE_BODY, "parsing never drops or duplicates a character");
 
 check(
   parseReleaseNote(RELEASE_NOTE_BODY).some((s) => s.kind === "link"),
   "this release's note actually contains a link",
 );
+
+/* Emphasis. Added for the 1.3.0 note, which leads with a bulleted list of feature names — a
+   `**` that silently rendered as literal asterisks would be visible to every user on update. */
+const bold = parseReleaseNote("Try **Gapless** today");
+equal(bold.length, 3, "emphasis splits the line in three");
+equal(bold[1].kind, "strong", "the middle piece is emphasised");
+equal(bold[1].kind === "strong" ? bold[1].value : "", "Gapless", "and the markers are stripped");
+
+const mixed = parseReleaseNote("**Equaliser** — see /r/myzuno");
+equal(mixed.filter((s) => s.kind === "strong").length, 1, "emphasis and links coexist");
+equal(mixed.filter((s) => s.kind === "link").length, 1, "the link still resolves alongside it");
+
+check(
+  parseReleaseNote(RELEASE_NOTE_BODY).some((s) => s.kind === "strong"),
+  "this release's note actually uses emphasis",
+);
+
+// Unpaired markers are prose, not broken markup: the note is hand-written per release.
+equal(parseReleaseNote("2 ** 3 is eight").length, 1, "a lone marker stays text");
 
 console.log("releaseNote self-check passed");

--- a/src/internal/releaseNote.ts
+++ b/src/internal/releaseNote.ts
@@ -10,9 +10,12 @@ import { getAppSetting, setAppSetting } from "./appSettings";
  */
 const SEEN_VERSION_KEY = "release-note-seen-version";
 
-export const RELEASE_NOTE_BODY = `Tracks start noticeably faster this time, and skipping ahead is close to instant.
+export const RELEASE_NOTE_BODY = `Playback now runs through a native Opus codec inside Zuno, instead of a hidden YouTube frame. Together with the rest of this release's optimisation work, that brings memory down to around 180 MB.
 
-Settings now has a native audio engine you can switch to — it drops the hidden YouTube frame and about 90 MB with it. You can also let Zuno add plays to your YouTube Music history, and albums show in track lists with a link straight to them.
+**Gapless** — no silence between tracks, on streams, downloads and your own files alike.
+**Crossfade** — overlap the end of each track with the start of the next.
+**Equaliser** — ten bands and presets in Settings, applied to whatever is playing.
+**Playback method** — the new engine is the default. Settings still has the old ones.
 
 Report anything broken on GitHub, or come say hello at /r/myzuno.
 
@@ -20,18 +23,20 @@ Thanks :)`;
 
 export type ReleaseNoteSegment =
   | { kind: "text"; value: string }
+  | { kind: "strong"; value: string }
   | { kind: "link"; value: string; url: string };
 
-/* Subreddits and bare URLs. Kept narrow on purpose: `/r/name` is unambiguous, and anything
-   cleverer would start linkifying ordinary prose. */
-const LINK_PATTERN = /(https?:\/\/[^\s)]+|\/r\/[A-Za-z0-9_]+)/g;
+/* Subreddits, bare URLs, and `**emphasis**`. Kept narrow on purpose: `/r/name` is unambiguous
+   and `**` is not something anyone types by accident, where anything cleverer would start
+   marking up ordinary prose. Still not markdown — three shapes, no escaping question. */
+const SEGMENT_PATTERN = /(\*\*[^*\n]+\*\*|https?:\/\/[^\s)]+|\/r\/[A-Za-z0-9_]+)/g;
 
 /**
- * Splits the note into text and links.
+ * Splits the note into text, emphasis and links.
  *
- * The body stays a plain string so writing the next release's note is just typing — mention a
- * subreddit or paste a URL and it becomes a link, with no markup to get wrong and no markdown
- * renderer to escape against.
+ * The body stays a plain string so writing the next release's note is mostly just typing —
+ * mention a subreddit or paste a URL and it becomes a link, wrap a phrase in `**` and it stands
+ * out. Three conventions, no markdown renderer and no escaping question.
  */
 export function parseReleaseNote(body: string): ReleaseNoteSegment[] {
   const segments: ReleaseNoteSegment[] = [];
@@ -39,18 +44,22 @@ export function parseReleaseNote(body: string): ReleaseNoteSegment[] {
 
   // `matchAll` rather than a stateful `exec` loop: the regex is module-level, and a shared
   // `lastIndex` across calls is the classic way this silently skips matches on a second run.
-  for (const match of body.matchAll(LINK_PATTERN)) {
+  for (const match of body.matchAll(SEGMENT_PATTERN)) {
     const value = match[0];
     const start = match.index ?? 0;
 
     if (start > lastIndex) {
       segments.push({ kind: "text", value: body.slice(lastIndex, start) });
     }
-    segments.push({
-      kind: "link",
-      value,
-      url: value.startsWith("/r/") ? `https://www.reddit.com${value}` : value,
-    });
+    if (value.startsWith("**")) {
+      segments.push({ kind: "strong", value: value.slice(2, -2) });
+    } else {
+      segments.push({
+        kind: "link",
+        value,
+        url: value.startsWith("/r/") ? `https://www.reddit.com${value}` : value,
+      });
+    }
     lastIndex = start + value.length;
   }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -16,6 +16,7 @@ import { hydrateQueuePanelSettings } from "./ui/settings/queuePanel";
 import { hydrateTraySettings } from "./ui/settings/tray";
 import { hydrateAudioQualitySettings } from "./internal/audioQuality";
 import { hydrateAudioEngineMode } from "./ui/settings/audioEngine";
+import { hydrateEqualizer } from "./ui/settings/equalizer";
 import { hydrateYouTubeAccountSettings } from "./ui/settings/youtubeAccount";
 import { notifyLocalPlaylistsChanged, syncLocalAudioWatcher } from "./player/localPlaylists";
 import { listen } from "@tauri-apps/api/event";
@@ -59,6 +60,8 @@ void Promise.all([
   hydrateTraySettings(),
   hydrateAudioQualitySettings(),
   hydrateAudioEngineMode(),
+  // Rust starts flat every launch, so the stored curve has to be pushed back down.
+  hydrateEqualizer(),
   hydrateYouTubeAccountSettings(),
   hydrateLastFmSettings(),
   hydrateDiscordSettings(),

--- a/src/player/AudioEngine.ts
+++ b/src/player/AudioEngine.ts
@@ -2,7 +2,10 @@ import { logInternalError, logInternalInfo, logInternalWarn } from "../internal/
 import {
   AUDIO_ENGINE_MODE_CHANGE_EVENT,
   usesNativeAudioEngine,
+  usesRustAudioEngine,
 } from "../ui/settings/audioEngine";
+import type { RustAudioSource } from "../datasource/types";
+import * as rustAudio from "./rustAudio";
 
 type YouTubePlayerEvent = {
   data: number;
@@ -111,6 +114,24 @@ function shouldUseNativeAudio(): boolean {
   return usesNativeAudioEngine();
 }
 
+/*
+ * One `ended` subscription for the whole process, dispatched to whichever engine owns playback.
+ *
+ * Rust has a single engine but there is an `AudioEngine` per tab, so a per-engine subscription
+ * would have every tab handle the same event and advance its own queue — one track end skipping
+ * three. Installed on the first Rust load rather than at import so a listener on the IFrame
+ * engine never registers one.
+ */
+let rustEndedRouted = false;
+
+function routeRustEnded(): void {
+  if (rustEndedRouted) return;
+  rustEndedRouted = true;
+  rustAudio.setEndedListener(() => {
+    playbackOwner?.handleRustEnded();
+  });
+}
+
 function isPlayerStateTimeout(error: unknown): boolean {
   return error instanceof Error
     && /^Timed out waiting for YouTube player state: /.test(error.message);
@@ -171,6 +192,17 @@ export class AudioEngine {
     return shouldUseNativeAudio();
   }
 
+  /** Rust decodes and plays; nothing in this class touches a media element or an IFrame. */
+  private get useRustAudio(): boolean {
+    return usesRustAudioEngine();
+  }
+
+  /** What Rust has loaded on the active deck for this engine, or null. */
+  private rustTrackId: string | null = null;
+  /** What Rust has decoded on the standby deck, mirrored so `hasPreloaded` stays synchronous. */
+  private rustStandbyTrackId: string | null = null;
+  private rustDurationSec = 0;
+  private rustStandbyDurationSec = 0;
   private player: YouTubePlayer | null = null;
   private playerHost: HTMLElement | null = null;
   private playerPromise: Promise<YouTubePlayer> | null = null;
@@ -216,12 +248,28 @@ export class AudioEngine {
     return this.useNativeAudio;
   }
 
+  usesRustAudio(): boolean {
+    return this.useRustAudio;
+  }
+
   async loadTrack(
     videoId: string,
     audioData?: ArrayBuffer,
     mimeType?: string,
     sourceUrl?: string,
+    rustSource?: RustAudioSource,
+    durationSec?: number,
   ): Promise<void> {
+    if (this.useRustAudio) {
+      if (!rustSource) {
+        throw new Error("Rust playback requires a resolved audio source.");
+      }
+      this.releaseIframePlayer();
+      this.releaseNativeAudio();
+      await this.loadRustAudio(videoId, rustSource, durationSec ?? 0);
+      return;
+    }
+
     if (this.useNativeAudio) {
       if (!audioData && !sourceUrl) {
         throw new Error("Native playback requires downloaded audio data.");
@@ -269,8 +317,14 @@ export class AudioEngine {
     audioData?: ArrayBuffer,
     mimeType?: string,
     sourceUrl?: string,
+    rustSource?: RustAudioSource,
+    durationSec?: number,
   ): Promise<void> {
     this.player?.stopVideo();
+    if (this.useRustAudio && rustSource) {
+      await this.loadRustAudio(videoId, rustSource, durationSec ?? 0);
+      return;
+    }
     await this.loadNativeAudio(videoId, audioData, mimeType, sourceUrl);
   }
 
@@ -278,8 +332,19 @@ export class AudioEngine {
     this.onEnded = listener;
   }
 
+  /** Called by the process-wide Rust `ended` router, on the engine that owns playback. */
+  handleRustEnded(): void {
+    this.rustTrackId = null;
+    this.onEnded?.();
+  }
+
   async play(): Promise<boolean> {
     const claimId = this.claimPlayback();
+    if (this.rustTrackId) {
+      await rustAudio.setVolume(this.volume, this.muted);
+      await rustAudio.play();
+      return claimId === playbackClaimId && playbackOwner === this;
+    }
     if (this.useNativeAudio || this.audio) {
       if (!this.audio || !this.currentVideoId) {
         throw new Error("No audio track is loaded.");
@@ -373,6 +438,7 @@ export class AudioEngine {
   }
 
   pause(): void {
+    if (this.rustTrackId) void rustAudio.pause().catch(() => {});
     this.audio?.pause();
     this.player?.pauseVideo();
     this.scheduleStandbyTeardown();
@@ -396,6 +462,7 @@ export class AudioEngine {
       playbackClaimId += 1;
     }
     this.cancelFade();
+    this.releaseRustAudio();
     this.releaseNativeAudio();
     this.player?.stopVideo();
     this.discardStandby();
@@ -456,6 +523,12 @@ export class AudioEngine {
 
   seekTo(seconds: number): void {
     if (!Number.isFinite(seconds)) return;
+    if (this.rustTrackId) {
+      void rustAudio.seek(Math.max(0, seconds)).catch((error: unknown) => {
+        rustAudio.warn("AudioEngine rust seek failed", error);
+      });
+      return;
+    }
     if (this.audio) {
       this.audio.currentTime = Math.min(
         Math.max(0, seconds),
@@ -518,11 +591,20 @@ export class AudioEngine {
   }
 
   getCurrentTime(): number {
+    /*
+     * Rust reports one position for one engine, so an engine that is not the one it loaded
+     * would otherwise read another tab's playhead. The track id is the discriminator: the
+     * events carry it, and only the engine that loaded it matches.
+     */
+    if (this.rustTrackId) {
+      return rustAudio.getPositionTrackId() === this.rustTrackId ? rustAudio.getCurrentTime() : 0;
+    }
     if (this.audio) return this.audio.currentTime;
     return this.player?.getCurrentTime() ?? 0;
   }
 
   getDuration(): number {
+    if (this.rustTrackId) return this.rustDurationSec;
     if (this.audio) return Number.isFinite(this.audio.duration) ? this.audio.duration : 0;
     return this.player?.getDuration() ?? 0;
   }
@@ -535,6 +617,7 @@ export class AudioEngine {
    * native-audio path, which serves offline files that have no load latency to hide.
    */
   preloadNext(videoId: string): void {
+    if (this.useRustAudio) return;
     if (this.useNativeAudio || this.audio) return;
     if (!videoId || videoId === this.currentVideoId) return;
     if (this.standbyVideoId === videoId || this.standbyPromise) return;
@@ -552,8 +635,31 @@ export class AudioEngine {
       });
   }
 
+  /**
+   * Decodes a track onto the Rust standby deck.
+   *
+   * The IFrame path preloads from a video id alone, because the embed resolves its own stream.
+   * Rust needs the bytes, so this is driven from `PlayerController.warmNextTrack` — which was
+   * already resolving the next track's `StreamData` ahead of time for the native engine. The
+   * only new work is handing what it found to a second deck instead of holding it in a slot.
+   */
+  async preloadRustTrack(
+    trackId: string,
+    source: RustAudioSource,
+    durationSec: number,
+  ): Promise<void> {
+    if (!this.useRustAudio || !trackId || trackId === this.rustTrackId) return;
+    if (this.rustStandbyTrackId === trackId) return;
+
+    routeRustEnded();
+    this.rustStandbyDurationSec = await rustAudio.load(trackId, source, durationSec, true);
+    this.rustStandbyTrackId = trackId;
+    logInternalInfo("AudioEngine rust preloaded", { trackId });
+  }
+
   /** Whether a transition to `videoId` can skip loading entirely. */
   hasPreloaded(videoId: string): boolean {
+    if (this.useRustAudio) return this.rustStandbyTrackId === videoId;
     return this.standbyPlayer !== null && this.standbyVideoId === videoId;
   }
 
@@ -569,6 +675,29 @@ export class AudioEngine {
    */
   async transitionToPreloaded(videoId: string, fadeMs: number): Promise<boolean> {
     if (!this.hasPreloaded(videoId)) return false;
+
+    if (this.useRustAudio) {
+      /*
+       * The whole transition happens in Rust: the standby deck is already decoded, so a zero
+       * fade starts it and stops the outgoing one in the same tick, and a non-zero fade ramps
+       * their volumes past each other on the audio thread. This is the case the `<audio>` path
+       * could never serve — one element, one body, nothing to fade against.
+       */
+      const swapped = await rustAudio.transition(videoId, Math.max(0, Math.round(fadeMs)));
+      if (!swapped) {
+        this.rustStandbyTrackId = null;
+        return false;
+      }
+      this.rustStandbyTrackId = null;
+      this.rustTrackId = videoId;
+      this.rustDurationSec = this.rustStandbyDurationSec;
+      this.rustStandbyDurationSec = 0;
+      this.currentVideoId = videoId;
+      this.loadRequestId += 1;
+      rustAudio.adoptTransitioned(videoId, this.rustDurationSec);
+      logInternalInfo("AudioEngine.transitionToPreloaded rust", { videoId, fadeMs });
+      return true;
+    }
 
     const outgoing = this.player;
     const outgoingHost = this.playerHost;
@@ -706,6 +835,65 @@ export class AudioEngine {
     }
   }
 
+  /**
+   * Decodes a track onto the active Rust deck.
+   *
+   * The `await` here is over the decoder reading the container header, not over the download:
+   * a stream is published to Rust as an empty buffer sized from the URL's own `clen` and filled
+   * behind this call, so what a click waits for is the first 128 KiB rather than the whole song.
+   * That is the defect this engine exists to fix — the `<audio>` path could not be pointed at a
+   * body until enough of it had been published to decode.
+   */
+  private async loadRustAudio(
+    videoId: string,
+    source: RustAudioSource,
+    durationSec: number,
+  ): Promise<void> {
+    const requestId = ++this.loadRequestId;
+    routeRustEnded();
+
+    // Dropping the standby first: it holds a decoded song, and a load that is not a transition
+    // means whatever was queued behind the old track is no longer next.
+    if (this.rustStandbyTrackId) {
+      this.rustStandbyTrackId = null;
+      this.rustStandbyDurationSec = 0;
+      await rustAudio.dropStandby().catch(() => {});
+    }
+
+    const duration = await rustAudio.load(videoId, source, durationSec);
+    if (requestId !== this.loadRequestId) return;
+
+    this.rustTrackId = videoId;
+    this.rustDurationSec = duration;
+    this.currentVideoId = videoId;
+    await rustAudio.setVolume(this.volume, this.muted);
+    await rustAudio.setRate(this.playbackRate);
+    logInternalInfo("AudioEngine rust audio loaded", {
+      videoId,
+      kind: source.kind,
+      durationSec: duration,
+    });
+  }
+
+  private releaseRustAudio(): void {
+    if (!this.rustTrackId && !this.rustStandbyTrackId) return;
+    /*
+     * There is one Rust engine behind every tab's `AudioEngine`, so `stop` is not this object's
+     * to call unless it is the one making sound. Closing a background tab disposes its engine,
+     * and without this that would cut off the tab that is actually playing. Its own bookkeeping
+     * is cleared either way — those decks belong to somebody else now.
+     */
+    const ownsRustPlayback = playbackOwner === null || playbackOwner === this;
+    this.rustTrackId = null;
+    this.rustStandbyTrackId = null;
+    this.rustDurationSec = 0;
+    this.rustStandbyDurationSec = 0;
+    if (!ownsRustPlayback) return;
+    void rustAudio.stop().catch((error: unknown) => {
+      rustAudio.warn("AudioEngine rust stop failed", error);
+    });
+  }
+
   private async loadNativeAudio(
     videoId: string,
     audioData?: ArrayBuffer,
@@ -789,6 +977,11 @@ export class AudioEngine {
   /** 1 is normal speed. Applies to whichever backend is currently playing. */
   setPlaybackRate(rate: number): void {
     this.playbackRate = Math.min(4, Math.max(0.25, rate));
+    if (this.useRustAudio) {
+      void rustAudio.setRate(this.playbackRate).catch((error: unknown) => {
+        rustAudio.warn("AudioEngine rust rate failed", error);
+      });
+    }
     this.applyNativeAudioSettings();
     this.player?.setPlaybackRate?.(this.playbackRate);
   }
@@ -798,6 +991,11 @@ export class AudioEngine {
   }
 
   private applyOutputVolume(): void {
+    if (this.rustTrackId) {
+      void rustAudio.setVolume(this.volume, this.muted).catch((error: unknown) => {
+        rustAudio.warn("AudioEngine rust volume failed", error);
+      });
+    }
     if (this.audio) {
       this.audio.volume = this.muted ? 0 : this.volume;
     }
@@ -852,6 +1050,7 @@ export class AudioEngine {
   }
 
   private pauseForPlaybackClaim(): void {
+    if (this.rustTrackId) void rustAudio.pause().catch(() => {});
     this.audio?.pause();
     this.player?.pauseVideo();
     // The standby is cued rather than playing, but a mid-crossfade claim would otherwise

--- a/src/player/AudioEngine.ts
+++ b/src/player/AudioEngine.ts
@@ -124,6 +124,15 @@ function shouldUseNativeAudio(): boolean {
  */
 let rustEndedRouted = false;
 
+/*
+ * The media server is released once per switch to the Rust engine, not once per track.
+ *
+ * Cleared again by `loadNativeAudio`, because that path is what refills the server — switching
+ * back and forth has to release each time, and a flag that only ever latched would leak the
+ * bodies of every track played after the first return trip.
+ */
+let mediaServerReleased = false;
+
 function routeRustEnded(): void {
   if (rustEndedRouted) return;
   rustEndedRouted = true;
@@ -265,7 +274,7 @@ export class AudioEngine {
         throw new Error("Rust playback requires a resolved audio source.");
       }
       this.releaseIframePlayer();
-      this.releaseNativeAudio();
+      // `loadRustAudio` releases the `<audio>` element itself, so both entry points get it.
       await this.loadRustAudio(videoId, rustSource, durationSec ?? 0);
       return;
     }
@@ -851,6 +860,25 @@ export class AudioEngine {
   ): Promise<void> {
     const requestId = ++this.loadRequestId;
     routeRustEnded();
+    /*
+     * Both entry points come through here, and this one has to run before the media server is
+     * released: the element it tears down is the only thing that could still be reading from
+     * the server, and clearing the bodies underneath a live range request would 404 the song
+     * that is playing.
+     */
+    this.releaseNativeAudio();
+    if (!mediaServerReleased) {
+      mediaServerReleased = true;
+      void rustAudio.releaseMediaServer()
+        .then((released) => {
+          if (released > 0) logInternalInfo("AudioEngine media server released", { released });
+        })
+        .catch((error: unknown) => {
+          // Nothing depends on this landing — it reclaims memory, it does not enable playback.
+          mediaServerReleased = false;
+          rustAudio.warn("AudioEngine media server release failed", error);
+        });
+    }
 
     // Dropping the standby first: it holds a decoded song, and a load that is not a transition
     // means whatever was queued behind the old track is no longer next.
@@ -901,6 +929,9 @@ export class AudioEngine {
     sourceUrl?: string,
   ): Promise<void> {
     const requestId = ++this.loadRequestId;
+    // This is the path that publishes bodies to the media server, so a later switch back to the
+    // Rust engine has something to release again.
+    mediaServerReleased = false;
     this.releaseNativeAudio();
 
     const bytes = audioData ? new Uint8Array(audioData) : null;

--- a/src/player/AudioEngine.ts
+++ b/src/player/AudioEngine.ts
@@ -212,6 +212,16 @@ export class AudioEngine {
   private rustStandbyTrackId: string | null = null;
   private rustDurationSec = 0;
   private rustStandbyDurationSec = 0;
+  /**
+   * This track is on the IFrame deck even though the selected engine is not `iframe`.
+   *
+   * Every other branch here asks *what is loaded* — `rustTrackId`, `audio` — rather than what
+   * the setting says, and falls through to the player when neither is. The exception is the
+   * `<audio>` branch, which also fires on the setting alone so that native mode reports "no
+   * track loaded" rather than silently doing nothing; this flag is what stops that branch from
+   * claiming a track the IFrame deck is holding.
+   */
+  private iframeFallbackActive = false;
   private player: YouTubePlayer | null = null;
   private playerHost: HTMLElement | null = null;
   private playerPromise: Promise<YouTubePlayer> | null = null;
@@ -293,6 +303,28 @@ export class AudioEngine {
       return;
     }
 
+    await this.loadIframeTrack(videoId);
+  }
+
+  /**
+   * Plays a track on the IFrame deck regardless of which engine is selected.
+   *
+   * The Rust engine resolves a signed googlevideo URL and can be refused; the IFrame player is
+   * Google's own embed resolving its own URLs, so it is the one path that cannot 403. That is
+   * why it was the only engine between v1.2.65 and PO tokens landing, and it is what keeps a
+   * refusal from becoming a dead track now that Rust is the default.
+   *
+   * Costs the `youtube.com` subframe for this track only — the next one tries Rust again.
+   */
+  async loadIframeFallback(videoId: string): Promise<void> {
+    this.releaseRustAudio();
+    this.releaseNativeAudio();
+    this.iframeFallbackActive = true;
+    await this.loadIframeTrack(videoId);
+    logInternalWarn("AudioEngine fell back to the YouTube player", { videoId });
+  }
+
+  private async loadIframeTrack(videoId: string): Promise<void> {
     const requestId = ++this.loadRequestId;
     this.releaseNativeAudio();
     const player = await this.ensurePlayer();
@@ -354,7 +386,7 @@ export class AudioEngine {
       await rustAudio.play();
       return claimId === playbackClaimId && playbackOwner === this;
     }
-    if (this.useNativeAudio || this.audio) {
+    if (this.audio || (this.useNativeAudio && !this.iframeFallbackActive)) {
       if (!this.audio || !this.currentVideoId) {
         throw new Error("No audio track is loaded.");
       }
@@ -471,6 +503,7 @@ export class AudioEngine {
       playbackClaimId += 1;
     }
     this.cancelFade();
+    this.iframeFallbackActive = false;
     this.releaseRustAudio();
     this.releaseNativeAudio();
     this.player?.stopVideo();
@@ -859,6 +892,7 @@ export class AudioEngine {
     durationSec: number,
   ): Promise<void> {
     const requestId = ++this.loadRequestId;
+    this.iframeFallbackActive = false;
     routeRustEnded();
     /*
      * Both entry points come through here, and this one has to run before the media server is
@@ -929,6 +963,7 @@ export class AudioEngine {
     sourceUrl?: string,
   ): Promise<void> {
     const requestId = ++this.loadRequestId;
+    this.iframeFallbackActive = false;
     // This is the path that publishes bodies to the media server, so a later switch back to the
     // Rust engine has something to release again.
     mediaServerReleased = false;
@@ -1008,7 +1043,7 @@ export class AudioEngine {
   /** 1 is normal speed. Applies to whichever backend is currently playing. */
   setPlaybackRate(rate: number): void {
     this.playbackRate = Math.min(4, Math.max(0.25, rate));
-    if (this.useRustAudio) {
+    if (this.useRustAudio && !this.iframeFallbackActive) {
       void rustAudio.setRate(this.playbackRate).catch((error: unknown) => {
         rustAudio.warn("AudioEngine rust rate failed", error);
       });

--- a/src/player/PlayerController.ts
+++ b/src/player/PlayerController.ts
@@ -1174,31 +1174,56 @@ export class PlayerController {
        * and holding it after use would keep a stale URL alive for a track already playing.
        */
       const warmed = this.claimWarmedStream(track.id);
-      const audioData = useNativeAudio
-        ? warmed ?? await this.dataSource.getStreamData?.(track)
-        : undefined;
-      if (useNativeAudio && !audioData) {
-        throw new Error("The data source does not support native audio playback.");
-      }
 
-      if (isDownloaded && audioData) {
-        await this.audioEngine.loadNativeFallback(
-          track.id,
-          audioData.bytes,
-          audioData.mimeType,
-          audioData.sourceUrl,
-          audioData.rustSource,
-          track.durationSec,
-        );
-      } else {
-        await this.audioEngine.loadTrack(
-          track.id,
-          audioData?.bytes,
-          audioData?.mimeType,
-          audioData?.sourceUrl,
-          audioData?.rustSource,
-          track.durationSec,
-        );
+      /*
+       * A streamed track on the Rust engine gets the IFrame deck as a safety net.
+       *
+       * Both halves of this can be refused by Google and neither is the listener's fault:
+       * resolving needs a PO token and an InnerTube `player` call, and fetching the signed URL
+       * needs googlevideo to honour it. The IFrame player is the one path that cannot 403 — it
+       * is Google's own embed resolving its own URLs — which is exactly why it was the only
+       * engine between v1.2.65 and PO tokens landing.
+       *
+       * Only for streaming. Local files returned above and have no IFrame equivalent anyway,
+       * and falling back for a *download* would stream the online copy of a track the user
+       * saved on purpose.
+       */
+      const canFallBackToIframe = this.audioEngine.usesRustAudio() && !isDownloaded;
+
+      try {
+        const audioData = useNativeAudio
+          ? warmed ?? await this.dataSource.getStreamData?.(track)
+          : undefined;
+        if (useNativeAudio && !audioData) {
+          throw new Error("The data source does not support native audio playback.");
+        }
+
+        if (isDownloaded && audioData) {
+          await this.audioEngine.loadNativeFallback(
+            track.id,
+            audioData.bytes,
+            audioData.mimeType,
+            audioData.sourceUrl,
+            audioData.rustSource,
+            track.durationSec,
+          );
+        } else {
+          await this.audioEngine.loadTrack(
+            track.id,
+            audioData?.bytes,
+            audioData?.mimeType,
+            audioData?.sourceUrl,
+            audioData?.rustSource,
+            track.durationSec,
+          );
+        }
+      } catch (error) {
+        if (!canFallBackToIframe) throw error;
+        logInternalWarn("PlayerController.ensureTrackLoaded falling back to the YouTube player", {
+          trackId: track.id,
+          error: getErrorMessage(error),
+        });
+        await this.audioEngine.loadIframeFallback(track.id);
       }
 
       this.loadedTrackId = track.id;

--- a/src/player/PlayerController.ts
+++ b/src/player/PlayerController.ts
@@ -1097,7 +1097,7 @@ export class PlayerController {
        * handover is a volume ramp between two live players — no load, and no silence between
        * them. A zero-length fade is the gapless case and swaps in the same tick.
        */
-      if (this.usesIframePlayback(track) && this.audioEngine.hasPreloaded(track.id)) {
+      if (this.usesPreloadDeck(track) && this.audioEngine.hasPreloaded(track.id)) {
         const swapped = await this.audioEngine.transitionToPreloaded(
           track.id,
           this.crossfadeSec * 1000,
@@ -1105,11 +1105,21 @@ export class PlayerController {
         if (swapped) {
           this.loadedTrackId = track.id;
           this.pendingSeekTime = null;
+          // The deck already holds these bytes, so the slot is stale rather than useful.
+          this.claimWarmedStream(track.id);
           logInternalInfo("PlayerController.ensureTrackLoaded preloaded deck", {
             trackId: track.id,
             crossfadeSec: this.crossfadeSec,
             durationMs: Math.round(performance.now() - startedAt),
           });
+          /*
+           * Warming has to continue from here too, or the chain stops after one transition:
+           * this branch returns before the ordinary load path's call, so the deck that just
+           * became active would have nothing queued behind it and the next track would load
+           * from cold — the first gapless handover would also be the last.
+           */
+          this.warmNextTrack();
+          this.beginPlayReport(track);
           return;
         }
       }
@@ -1124,6 +1134,8 @@ export class PlayerController {
           audioData.bytes,
           audioData.mimeType,
           audioData.sourceUrl,
+          audioData.rustSource,
+          track.durationSec,
         );
         this.loadedTrackId = track.id;
         if (this.pendingSeekTime !== null) {
@@ -1166,6 +1178,8 @@ export class PlayerController {
           audioData.bytes,
           audioData.mimeType,
           audioData.sourceUrl,
+          audioData.rustSource,
+          track.durationSec,
         );
       } else {
         await this.audioEngine.loadTrack(
@@ -1173,6 +1187,8 @@ export class PlayerController {
           audioData?.bytes,
           audioData?.mimeType,
           audioData?.sourceUrl,
+          audioData?.rustSource,
+          track.durationSec,
         );
       }
 
@@ -1274,9 +1290,17 @@ export class PlayerController {
     const getStreamData = this.dataSource.getStreamData.bind(this.dataSource);
     this.warmingStream = true;
     void getStreamData(next)
-      .then((data) => {
+      .then(async (data) => {
         this.warmedStream = { trackId: next.id, data };
         logInternalDebug("PlayerController.warmNextTrack audio ready", { trackId: next.id });
+        /*
+         * On the Rust engine the warmed stream goes one step further and is decoded onto the
+         * standby deck, which is what `ensureTrackLoaded` then transitions to. Held in the slot
+         * as well, so a transition that misses — a skip past this track and back, say — still
+         * finds the resolved URL rather than paying for it twice.
+         */
+        if (!data.rustSource || !this.audioEngine.usesRustAudio()) return;
+        await this.audioEngine.preloadRustTrack(next.id, data.rustSource, next.durationSec ?? 0);
       })
       .catch((error) => {
         logInternalWarn("PlayerController.warmNextTrack audio failed", {
@@ -1305,16 +1329,18 @@ export class PlayerController {
   }
 
   /**
-   * Whether a track plays through the IFrame deck rather than an audio element.
+   * Whether a track can be handed to a standby deck rather than loaded on the spot.
    *
-   * Only the IFrame path has a deck to preload. Offline and local files are read from disk
-   * with no load gap worth hiding, and handing one of those to the standby deck would play the
-   * streamed version of a track the user downloaded on purpose.
+   * Two engines have one: the IFrame pair, and the Rust pair. The `<audio>` engine does not,
+   * which is why gapless and crossfade quietly did nothing whenever it was selected.
+   *
+   * Offline and local files are excluded either way — they are read from disk with no load gap
+   * worth hiding, and handing one to the IFrame deck would play the streamed version of a track
+   * the user downloaded on purpose.
    */
-  private usesIframePlayback(track: Track): boolean {
-    return track.source !== "local"
-      && !isTrackDownloaded(track.id)
-      && !this.audioEngine.usesNativeAudio();
+  private usesPreloadDeck(track: Track): boolean {
+    if (track.source === "local" || isTrackDownloaded(track.id)) return false;
+    return this.audioEngine.usesRustAudio() || !this.audioEngine.usesNativeAudio();
   }
 
   /**
@@ -1389,7 +1415,7 @@ export class PlayerController {
     if (!(duration > 0) || !Number.isFinite(remaining) || remaining <= 0) return;
 
     const next = this.peekNextTrack();
-    if (!next || !this.usesIframePlayback(next)) return;
+    if (!next || !this.usesPreloadDeck(next)) return;
 
     if (remaining <= PRELOAD_LEAD_SEC) this.audioEngine.preloadNext(next.id);
 

--- a/src/player/PlayerController.ts
+++ b/src/player/PlayerController.ts
@@ -6,6 +6,8 @@ import { Queue } from "./Queue";
 import { recordPlay } from "./playHistory";
 import { computeQueueWindow } from "./queueWindow";
 import { getOfflineTrack, isTrackDownloaded } from "./offlineStore";
+import { hasPreloadDeck } from "./preloadDeck";
+import { getAudioEngineMode } from "../ui/settings/audioEngine";
 import { DiscordRpcService } from "./DiscordRPC";
 import {
   MAX_CROSSFADE_SEC,
@@ -1146,6 +1148,13 @@ export class PlayerController {
           trackId: track.id,
           durationMs: Math.round(performance.now() - startedAt),
         });
+        /*
+         * Warm from here too, or a local playlist never gets a second track onto the standby
+         * deck and every gapless handover it should have had is a gap instead. This branch used
+         * to return before the call below because nothing on the local path could be warmed —
+         * the Rust decks changed that.
+         */
+        this.warmNextTrack();
         return;
       }
       /*
@@ -1283,8 +1292,21 @@ export class PlayerController {
     if (!this.audioEngine.usesNativeAudio()) return;
     if (!this.dataSource.getStreamData) return;
     if (this.warmingStream) return;
-    // Local files and downloads are read from disk; there is no network wait to hide.
-    if (next.source === "local" || isTrackDownloaded(next.id)) return;
+    /*
+     * A track already on disk has no network wait to hide, which is all warming ever did on the
+     * `<audio>` engine — so it stays excluded there.
+     *
+     * On the Rust engine warming is not about the network. It decodes the next track onto the
+     * standby deck, and that is the whole mechanism behind gapless. Skipping it here is what
+     * left a downloaded album with a gap between every track while a streamed one played
+     * through seamlessly, which is exactly backwards.
+     */
+    if (
+      (next.source === "local" || isTrackDownloaded(next.id))
+      && !this.audioEngine.usesRustAudio()
+    ) {
+      return;
+    }
     if (this.warmedStream?.trackId === next.id) return;
 
     const getStreamData = this.dataSource.getStreamData.bind(this.dataSource);
@@ -1328,19 +1350,12 @@ export class PlayerController {
     return data;
   }
 
-  /**
-   * Whether a track can be handed to a standby deck rather than loaded on the spot.
-   *
-   * Two engines have one: the IFrame pair, and the Rust pair. The `<audio>` engine does not,
-   * which is why gapless and crossfade quietly did nothing whenever it was selected.
-   *
-   * Offline and local files are excluded either way — they are read from disk with no load gap
-   * worth hiding, and handing one to the IFrame deck would play the streamed version of a track
-   * the user downloaded on purpose.
-   */
+  /** Whether a track can be handed to a standby deck rather than loaded on the spot. */
   private usesPreloadDeck(track: Track): boolean {
-    if (track.source === "local" || isTrackDownloaded(track.id)) return false;
-    return this.audioEngine.usesRustAudio() || !this.audioEngine.usesNativeAudio();
+    return hasPreloadDeck(getAudioEngineMode(), {
+      isLocal: track.source === "local",
+      isDownloaded: isTrackDownloaded(track.id),
+    });
   }
 
   /**

--- a/src/player/preloadDeck.check.ts
+++ b/src/player/preloadDeck.check.ts
@@ -1,0 +1,41 @@
+/**
+ * Self-check for which engines may preload which tracks. There is no test runner in this
+ * project, so it runs via esbuild:
+ *
+ *   npx esbuild src/player/preloadDeck.check.ts --bundle --platform=node --format=esm
+ *     --outfile=check.mjs && node check.mjs
+ *
+ * Worth pinning because both mistakes are real bugs and neither is loud. Excluding downloads
+ * from the Rust deck silently costs gapless on exactly the albums people expect it on;
+ * *including* them on the IFrame deck would stream the online copy of a track the user
+ * downloaded on purpose, over the network, while a perfectly good file sat on disk.
+ */
+export {};
+
+import { hasPreloadDeck } from "./preloadDeck";
+
+function check(condition: boolean, message: string): void {
+  if (!condition) throw new Error(`FAILED: ${message}`);
+}
+
+const streamed = { isLocal: false, isDownloaded: false };
+const downloaded = { isLocal: false, isDownloaded: true };
+const local = { isLocal: true, isDownloaded: false };
+
+// The Rust decks open whatever they are handed, so nothing is held back from them.
+check(hasPreloadDeck("rust", streamed), "rust preloads a streamed track");
+check(hasPreloadDeck("rust", downloaded), "rust preloads a downloaded track");
+check(hasPreloadDeck("rust", local), "rust preloads a local file");
+
+// The IFrame decks resolve their own stream from a video id, so a track already on disk would
+// come back over the network as the online copy.
+check(hasPreloadDeck("iframe", streamed), "iframe preloads a streamed track");
+check(!hasPreloadDeck("iframe", downloaded), "iframe must not restream a download");
+check(!hasPreloadDeck("iframe", local), "iframe cannot play a local file at all");
+
+// One `<audio>` element, one body, no standby.
+check(!hasPreloadDeck("native", streamed), "native has no second deck to preload onto");
+check(!hasPreloadDeck("native", downloaded), "native has no second deck, downloaded or not");
+check(!hasPreloadDeck("native", local), "native has no second deck for local files either");
+
+console.log("preloadDeck.check.ts OK");

--- a/src/player/preloadDeck.ts
+++ b/src/player/preloadDeck.ts
@@ -1,0 +1,42 @@
+import type { AudioEngineMode } from "../ui/settings/audioEngine";
+
+/**
+ * The only two things about a track that decide whether it may be preloaded.
+ *
+ * Both mean "these bytes are already on this machine", which is what the IFrame deck cannot
+ * honour and the Rust deck can.
+ */
+export type PreloadSubject = {
+  /** A file the user pointed a music folder at. */
+  isLocal: boolean;
+  /** A YouTube track whose bytes are in the offline store. */
+  isDownloaded: boolean;
+};
+
+/**
+ * Whether a track can be loaded onto a standby deck ahead of its turn.
+ *
+ * This is what gapless and crossfade ride on: with the next track already sitting decoded, a
+ * handover is a volume ramp between two live decks rather than a stop followed by a load.
+ *
+ * Which engines have a deck at all:
+ *
+ * - `iframe` has two, but they resolve their own stream from a video id. Handing one a track
+ *   the user downloaded on purpose would play the *online* copy instead, over the network,
+ *   which is why anything read from disk is excluded there.
+ * - `rust` has two, and they open whatever they are given — a signed URL, a file in the offline
+ *   store, a path on disk. Nothing is excluded, and a downloaded album is exactly where gapless
+ *   is wanted most.
+ * - `native` has no standby deck at all: one `<audio>` element, one body. Gapless and crossfade
+ *   have always silently done nothing there.
+ */
+export function hasPreloadDeck(engine: AudioEngineMode, track: PreloadSubject): boolean {
+  switch (engine) {
+    case "rust":
+      return true;
+    case "iframe":
+      return !track.isLocal && !track.isDownloaded;
+    default:
+      return false;
+  }
+}

--- a/src/player/rustAudio.ts
+++ b/src/player/rustAudio.ts
@@ -1,0 +1,159 @@
+/**
+ * The frontend half of the Rust audio engine.
+ *
+ * Rust owns decoding, output and the clock; this module owns the invoke calls and the cached
+ * position that makes them look synchronous. `AudioEngine` calls it and does not know it is
+ * talking to another process.
+ *
+ * Position is pushed rather than polled: Rust emits `native-audio-position` every 250 ms, the
+ * same cadence `PlayerController` ticks at. `getCurrentTime()` has to be synchronous — it is
+ * read on every progress frame — so it answers from the last event rather than awaiting an
+ * `invoke` that could not resolve in time anyway.
+ */
+
+import { invoke } from "@tauri-apps/api/core";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { logInternalWarn } from "../internal/logging";
+import type { RustAudioSource } from "../datasource/types";
+
+export type { RustAudioSource };
+
+type PositionEvent = {
+  trackId: string;
+  positionSec: number;
+  durationSec: number;
+};
+
+type EndedEvent = { trackId: string };
+
+let positionSec = 0;
+let durationSec = 0;
+let positionTrackId: string | null = null;
+let endedListener: (() => void) | null = null;
+let unlisten: Promise<UnlistenFn[]> | null = null;
+
+/*
+ * Subscribed once for the whole process, not once per engine.
+ *
+ * There is one Rust engine and one set of events, but a `PlayerController` — and therefore an
+ * `AudioEngine` — exists per tab. Listeners per engine would each handle every event and the
+ * `ended` callback would fire once per open tab, advancing the queue several times on one track
+ * end. Which engine owns `ended` is decided by `setEndedListener`, and only the playback owner
+ * ever sets it.
+ */
+function ensureListening(): Promise<UnlistenFn[]> {
+  if (!unlisten) {
+    unlisten = Promise.all([
+      listen<PositionEvent>("native-audio-position", (event) => {
+        positionTrackId = event.payload.trackId;
+        positionSec = event.payload.positionSec;
+        durationSec = event.payload.durationSec;
+      }),
+      listen<EndedEvent>("native-audio-ended", () => {
+        positionSec = 0;
+        positionTrackId = null;
+        endedListener?.();
+      }),
+    ]);
+  }
+  return unlisten;
+}
+
+export function setEndedListener(listener: (() => void) | null): void {
+  endedListener = listener;
+  if (listener) void ensureListening();
+}
+
+/**
+ * Decodes a track onto a deck. `standby` targets the idle deck, which `transition` later swaps
+ * to. Resolves with the duration Rust decoded, or `fallbackDurationSec` when the container
+ * declares none.
+ */
+export async function load(
+  trackId: string,
+  source: RustAudioSource,
+  fallbackDurationSec: number,
+  standby = false,
+): Promise<number> {
+  await ensureListening();
+  const duration = await invoke<number>("native_audio_load", {
+    trackId,
+    source,
+    durationSec: fallbackDurationSec,
+    standby,
+  });
+  if (!standby) {
+    positionTrackId = trackId;
+    positionSec = 0;
+    durationSec = duration;
+  }
+  return duration;
+}
+
+export function play(): Promise<void> {
+  return invoke("native_audio_play");
+}
+
+export function pause(): Promise<void> {
+  return invoke("native_audio_pause");
+}
+
+export async function stop(): Promise<void> {
+  positionSec = 0;
+  durationSec = 0;
+  positionTrackId = null;
+  await invoke("native_audio_stop");
+}
+
+export async function seek(seconds: number): Promise<void> {
+  // Written through immediately so the progress bar does not snap back to the old position for
+  // the up-to-250 ms before Rust's next event confirms the move.
+  positionSec = Math.max(0, seconds);
+  await invoke("native_audio_seek", { positionSec: positionSec });
+}
+
+export function setVolume(volume: number, muted: boolean): Promise<void> {
+  return invoke("native_audio_set_volume", { volume, muted });
+}
+
+export function setRate(rate: number): Promise<void> {
+  return invoke("native_audio_set_rate", { rate });
+}
+
+export function transition(trackId: string, fadeMs: number): Promise<boolean> {
+  return invoke<boolean>("native_audio_transition", { trackId, fadeMs });
+}
+
+export function hasStandby(trackId: string): Promise<boolean> {
+  return invoke<boolean>("native_audio_has_standby", { trackId });
+}
+
+export function dropStandby(): Promise<void> {
+  return invoke("native_audio_drop_standby");
+}
+
+export function getCurrentTime(): number {
+  return positionSec;
+}
+
+export function getDuration(): number {
+  return durationSec;
+}
+
+/** The track Rust last reported on, so a stale event for a skipped track can be ignored. */
+export function getPositionTrackId(): string | null {
+  return positionTrackId;
+}
+
+/** Records the deck swap on this side, since `transition` produces no load event. */
+export function adoptTransitioned(trackId: string, duration: number): void {
+  positionTrackId = trackId;
+  positionSec = 0;
+  durationSec = duration;
+}
+
+export function warn(context: string, error: unknown): void {
+  logInternalWarn(context, {
+    error: error instanceof Error ? error.message : String(error),
+  });
+}

--- a/src/player/rustAudio.ts
+++ b/src/player/rustAudio.ts
@@ -132,6 +132,20 @@ export function dropStandby(): Promise<void> {
   return invoke("native_audio_drop_standby");
 }
 
+/**
+ * Drops the audio bodies the local media server is holding.
+ *
+ * Not strictly a Rust-engine call, but this is its only caller: the media server exists to feed
+ * an `<audio>` element, and the Rust engine is the one path that has none. Lives here rather
+ * than in a module of its own because one invoke does not need one.
+ *
+ * Resolves with how many bodies were dropped — zero when the app launched straight into the
+ * Rust engine, because the server is lazy and was never started.
+ */
+export function releaseMediaServer(): Promise<number> {
+  return invoke<number>("media_server_release");
+}
+
 export function getCurrentTime(): number {
   return positionSec;
 }

--- a/src/ui/components/ReleaseNoteDialog.tsx
+++ b/src/ui/components/ReleaseNoteDialog.tsx
@@ -78,6 +78,13 @@ export function ReleaseNoteDialog({ version, onDismiss }: ReleaseNoteDialogProps
               {parseReleaseNote(RELEASE_NOTE_BODY).map((segment, index) =>
                 segment.kind === "text" ? (
                   segment.value
+                ) : segment.kind === "strong" ? (
+                  <strong
+                    key={`${index}:${segment.value}`}
+                    className="font-semibold text-foreground"
+                  >
+                    {segment.value}
+                  </strong>
                 ) : (
                   <button
                     key={`${index}:${segment.value}`}

--- a/src/ui/pages/SettingsPage.tsx
+++ b/src/ui/pages/SettingsPage.tsx
@@ -9,6 +9,14 @@ import {
 import { Switch } from "@/components/motion/switch";
 import { RangeSlider } from "@/components/motion/range-slider";
 import {
+  EQUALIZER_BANDS_HZ,
+  EQUALIZER_MAX_DB,
+  EQUALIZER_PRESETS,
+  isEqualizerFlat,
+  setEqualizer,
+  useEqualizer,
+} from "../settings/equalizer";
+import {
   MAX_CROSSFADE_SEC,
   setCrossfadeSec,
   setGaplessEnabled,
@@ -227,6 +235,130 @@ function formatSessionAge(confirmedAt: number | null): string {
  */
 const SETTINGS_FIELD =
   "min-w-0 rounded-lg bg-background px-2.5 py-1.5 text-sm text-foreground outline-none placeholder:text-muted-foreground focus:ring-2 focus:ring-inset focus:ring-ring/60";
+
+/**
+ * The ten-band equaliser.
+ *
+ * A component of its own rather than a run of `SettingRow`s because the bands are one control,
+ * not eleven: they share a scale, a reset and a set of presets, and reading one slider only
+ * means anything next to its neighbours.
+ *
+ * Sliders are horizontal, stacked. The usual picture of an equaliser is vertical, but that would
+ * mean a second slider component built to be rotated, and the frequency and the gain read more
+ * clearly written out than inferred from a bar's height.
+ */
+function EqualizerSettings({ engineMode }: { engineMode: AudioEngineMode }) {
+  const equalizer = useEqualizer();
+  // Only the Rust engine has the samples. A track that fell back to the YouTube player plays
+  // unequalised no matter what these say, which the note below is there to admit.
+  const available = engineMode === "rust";
+  const flat = isEqualizerFlat(equalizer);
+
+  const setBand = (index: number, gain: number) => {
+    const bandsDb = equalizer.bandsDb.slice();
+    bandsDb[index] = gain;
+    setEqualizer({ ...equalizer, bandsDb });
+  };
+
+  const activePreset = EQUALIZER_PRESETS.find(
+    (preset) =>
+      preset.settings.preampDb === equalizer.preampDb
+      && preset.settings.bandsDb.every((gain, index) => gain === equalizer.bandsDb[index]),
+  );
+
+  return (
+    <div className={cn("flex flex-col gap-3 pt-1", !available && "opacity-50")}>
+      <div className="flex items-baseline justify-between gap-4">
+        <span className="text-sm font-medium text-foreground">Equaliser</span>
+        <span className="text-xs text-muted-foreground">
+          {available
+            ? flat
+              ? "Off"
+              : `${equalizer.preampDb > 0 ? "+" : ""}${equalizer.preampDb} dB preamp`
+            : "Needs the Rust playback method"}
+        </span>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        {EQUALIZER_PRESETS.map((preset) => (
+          <button
+            key={preset.name}
+            type="button"
+            disabled={!available}
+            onClick={() => setEqualizer(preset.settings)}
+            className={cn(
+              "rounded-full px-3 py-1 text-xs font-medium transition-colors disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
+              activePreset?.name === preset.name
+                ? "bg-primary text-primary-foreground"
+                : "text-foreground hover:bg-card",
+            )}
+          >
+            {preset.name}
+          </button>
+        ))}
+      </div>
+
+      <EqualizerBand
+        label="Preamp"
+        value={equalizer.preampDb}
+        disabled={!available}
+        onChange={(preampDb) => setEqualizer({ ...equalizer, preampDb })}
+      />
+
+      <div className="h-px bg-border" />
+
+      {EQUALIZER_BANDS_HZ.map((hz, index) => (
+        <EqualizerBand
+          key={hz}
+          label={hz >= 1000 ? `${hz / 1000}k` : String(hz)}
+          value={equalizer.bandsDb[index]}
+          disabled={!available}
+          onChange={(gain) => setBand(index, gain)}
+        />
+      ))}
+
+      <p className="px-1 text-xs text-muted-foreground">
+        Applies immediately, to the track playing. A limiter sits after the bands, so a heavy
+        boost is held back rather than clipped — lower the preamp to hear the difference instead.
+      </p>
+    </div>
+  );
+}
+
+function EqualizerBand({
+  label,
+  value,
+  disabled,
+  onChange,
+}: {
+  label: string;
+  value: number;
+  disabled: boolean;
+  onChange: (value: number) => void;
+}) {
+  return (
+    <div className="flex items-center gap-3">
+      <span className="w-10 shrink-0 text-right text-xs tabular-nums text-muted-foreground">
+        {label}
+      </span>
+      <RangeSlider
+        className="min-w-0 flex-1"
+        value={value}
+        min={-EQUALIZER_MAX_DB}
+        max={EQUALIZER_MAX_DB}
+        step={1}
+        showTicks={false}
+        disabled={disabled}
+        onValueChange={onChange}
+        aria-label={`${label} gain in decibels`}
+      />
+      <span className="w-12 shrink-0 text-right text-xs tabular-nums text-muted-foreground">
+        {value > 0 ? "+" : ""}
+        {value} dB
+      </span>
+    </div>
+  );
+}
 
 /**
  * One settings row: label and description on the left, control on the right.
@@ -1826,6 +1958,8 @@ export function SettingsPage({
             <p className="px-1 text-xs text-muted-foreground">
               Applies from the next track.
             </p>
+
+            <EqualizerSettings engineMode={audioEngineMode} />
 
             <SettingToggle
               title="Resolve streams as your account"

--- a/src/ui/settings/audioEngine.ts
+++ b/src/ui/settings/audioEngine.ts
@@ -23,9 +23,11 @@ import {
  * real decks and mixes them, decodes as the bytes arrive rather than after, and never puts audio
  * in the renderer at all.
  *
- * `iframe` remains the default because it is the path that cannot 403: it is Google's own player
- * resolving its own URLs. Both others depend on a signed URL and a PO token, which is what
- * hardcoded `native` off between v1.2.65 and PO tokens landing.
+ * `rust` is the default. What made that safe is not that a signed URL never gets refused — it
+ * still can, and that is what hardcoded `native` off between v1.2.65 and PO tokens landing — but
+ * that a refusal is no longer fatal: `PlayerController` catches a failed resolve or load on a
+ * streamed track and plays it on the IFrame deck instead, costing that one track a subframe.
+ * `iframe` stays selectable for anyone who wants Google's player for everything.
  */
 export type AudioEngineMode = "iframe" | "native" | "rust";
 
@@ -33,7 +35,7 @@ const STORAGE_KEY = "audio-engine-mode";
 /** Exported so `AudioEngine` can free its decks the moment the mode stops being `iframe`. */
 export const AUDIO_ENGINE_MODE_CHANGE_EVENT = "audio-engine-mode-change";
 const CHANGE_EVENT = AUDIO_ENGINE_MODE_CHANGE_EVENT;
-const DEFAULT_MODE: AudioEngineMode = "iframe";
+const DEFAULT_MODE: AudioEngineMode = "rust";
 
 export const AUDIO_ENGINE_MODES: ReadonlyArray<{
   value: AudioEngineMode;
@@ -41,19 +43,19 @@ export const AUDIO_ENGINE_MODES: ReadonlyArray<{
   hint: string;
 }> = [
   {
+    value: "rust",
+    label: "Rust audio",
+    hint: "Decoded in the app. Lowest memory, gapless and crossfade, falls back if a track is refused.",
+  },
+  {
     value: "iframe",
     label: "YouTube player",
-    hint: "Most reliable. Runs a hidden youtube.com frame, ~90 MB.",
+    hint: "Google's own player for everything. Runs a hidden youtube.com frame, ~90 MB.",
   },
   {
     value: "native",
     label: "Native audio",
-    hint: "No hidden frame. Lower memory, slower to start, no gapless or crossfade.",
-  },
-  {
-    value: "rust",
-    label: "Rust audio",
-    hint: "Decoded in the app. Lowest memory, starts fastest, keeps gapless and crossfade.",
+    hint: "Plays through the webview. Keeps a second copy of each track in memory, no gapless.",
   },
 ];
 

--- a/src/ui/settings/audioEngine.ts
+++ b/src/ui/settings/audioEngine.ts
@@ -10,21 +10,24 @@ import {
  *
  * `iframe` hands the video id to a hidden YouTube IFrame player and lets Google's own embed
  * resolve and stream it. `native` resolves the signed URL here, downloads it through Rust, and
- * plays the bytes from the local media server through an `<audio>` element.
+ * plays the bytes from the local media server through an `<audio>` element. `rust` resolves the
+ * same URL and decodes it in the Rust process with symphonia, straight out to the sound card.
  *
  * The difference that matters is a whole second webview: the IFrame player runs in a
  * `youtube.com` subframe process of its own, which costs roughly 90 MB and a steady slice of
- * the GPU process. Native has no subframe at all.
+ * the GPU process. Neither of the other two has a subframe at all.
  *
- * Native is not the default *yet*, for three reasons: it resolves a signed URL and downloads
- * the whole track before the first sample plays, so it starts slower; it is the path that
- * historically answered 403, which is why this was hardcoded off until PO tokens landed; and
- * gapless and crossfade ride the standby IFrame deck, so neither applies to it. Downloads have
- * used this exact resolve-and-fetch path successfully since PO tokens, which is what makes it
- * worth offering — leaving the default alone means a regression costs a setting rather than
- * everyone's playback.
+ * `rust` is what `native` was trying to be. `native` still hands whole songs to the webview over
+ * loopback HTTP, which means a second copy of every track lives in the renderer, and it has no
+ * standby deck — so gapless and crossfade silently do nothing there. The Rust engine has two
+ * real decks and mixes them, decodes as the bytes arrive rather than after, and never puts audio
+ * in the renderer at all.
+ *
+ * `iframe` remains the default because it is the path that cannot 403: it is Google's own player
+ * resolving its own URLs. Both others depend on a signed URL and a PO token, which is what
+ * hardcoded `native` off between v1.2.65 and PO tokens landing.
  */
-export type AudioEngineMode = "iframe" | "native";
+export type AudioEngineMode = "iframe" | "native" | "rust";
 
 const STORAGE_KEY = "audio-engine-mode";
 /** Exported so `AudioEngine` can free its decks the moment the mode stops being `iframe`. */
@@ -47,10 +50,15 @@ export const AUDIO_ENGINE_MODES: ReadonlyArray<{
     label: "Native audio",
     hint: "No hidden frame. Lower memory, slower to start, no gapless or crossfade.",
   },
+  {
+    value: "rust",
+    label: "Rust audio",
+    hint: "Decoded in the app. Lowest memory, starts fastest, keeps gapless and crossfade.",
+  },
 ];
 
 function isAudioEngineMode(value: unknown): value is AudioEngineMode {
-  return value === "iframe" || value === "native";
+  return value === "iframe" || value === "native" || value === "rust";
 }
 
 /*
@@ -93,9 +101,21 @@ export function getAudioEngineMode(): AudioEngineMode {
   return readMode();
 }
 
-/** True when the current mode plays through `<audio>` rather than the YouTube IFrame. */
+/**
+ * True when playback does *not* go through the YouTube IFrame.
+ *
+ * Deliberately covers both non-iframe engines. Every caller of this asks the same question —
+ * "is a signed URL being resolved here rather than by Google's embed" — which is what gates
+ * stream warming, play reporting and the error copy. Use `usesRustAudioEngine` for the narrower
+ * question of *which* of the two.
+ */
 export function usesNativeAudioEngine(): boolean {
-  return readMode() === "native";
+  return readMode() !== "iframe";
+}
+
+/** True when Rust decodes and plays the audio itself, with no `<audio>` element involved. */
+export function usesRustAudioEngine(): boolean {
+  return readMode() === "rust";
 }
 
 export function setAudioEngineMode(mode: AudioEngineMode) {

--- a/src/ui/settings/equalizer.ts
+++ b/src/ui/settings/equalizer.ts
@@ -1,0 +1,156 @@
+import { useSyncExternalStore } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import {
+  hydrateLocalJsonSetting,
+  readLocalJsonSetting,
+  writeLocalJsonSetting,
+} from "../../internal/durableLocalSetting";
+import { logInternalWarn } from "../../internal/logging";
+import { usesRustAudioEngine } from "./audioEngine";
+
+/**
+ * Ten-band graphic equaliser.
+ *
+ * The gains live here; the filtering happens in Rust, between the decoder and the deck. That is
+ * also why this only works on the Rust engine — the IFrame player never exposes its samples, and
+ * a track that fell back to it plays unequalised however these sliders are set.
+ *
+ * Rust holds the current values in process-global state, so they survive track changes and apply
+ * to both decks during a crossfade. They do *not* survive a restart, which is why `hydrate` ends
+ * by pushing them back down.
+ */
+export const EQUALIZER_BANDS_HZ = [31, 62, 125, 250, 500, 1000, 2000, 4000, 8000, 16000] as const;
+
+/** Matches `MAX_GAIN_DB` in `equalizer.rs`, which clamps to the same range on the way in. */
+export const EQUALIZER_MAX_DB = 12;
+
+export type EqualizerSettings = {
+  preampDb: number;
+  bandsDb: number[];
+};
+
+export const EQUALIZER_FLAT: EqualizerSettings = {
+  preampDb: 0,
+  bandsDb: EQUALIZER_BANDS_HZ.map(() => 0),
+};
+
+/*
+ * Presets carry a negative preamp wherever they boost.
+ *
+ * A normalised track has very little headroom left, so lifting four bands by 6 dB without
+ * trimming the input hits the limiter and what comes out is compression rather than tone. Each
+ * preset gives back roughly what its largest boost takes.
+ */
+export const EQUALIZER_PRESETS: ReadonlyArray<{ name: string; settings: EqualizerSettings }> = [
+  { name: "Flat", settings: EQUALIZER_FLAT },
+  {
+    name: "Bass",
+    settings: { preampDb: -4, bandsDb: [6, 5, 4, 2, 0, 0, 0, 0, 0, 0] },
+  },
+  {
+    name: "Vocal",
+    settings: { preampDb: -3, bandsDb: [-2, -2, -1, 1, 3, 4, 3, 1, 0, 0] },
+  },
+  {
+    name: "Treble",
+    settings: { preampDb: -3, bandsDb: [0, 0, 0, 0, 0, 1, 2, 4, 5, 5] },
+  },
+];
+
+const STORAGE_KEY = "equalizer-v1";
+const CHANGE_EVENT = "equalizer-change";
+
+function isEqualizerSettings(value: unknown): value is EqualizerSettings {
+  if (typeof value !== "object" || value === null) return false;
+  const candidate = value as EqualizerSettings;
+  return typeof candidate.preampDb === "number"
+    && Array.isArray(candidate.bandsDb)
+    && candidate.bandsDb.length === EQUALIZER_BANDS_HZ.length
+    && candidate.bandsDb.every((gain) => typeof gain === "number");
+}
+
+/*
+ * Cached because the settings page reads this on every render of every slider, and the snapshot
+ * handed to `useSyncExternalStore` has to be reference-stable or React re-renders forever.
+ */
+let cached: EqualizerSettings | null = null;
+
+function readSettings(): EqualizerSettings {
+  if (cached === null) {
+    cached = readLocalJsonSetting(STORAGE_KEY, isEqualizerSettings) ?? EQUALIZER_FLAT;
+  }
+  return cached;
+}
+
+/** True when every band and the preamp are at zero, so nothing is being changed. */
+export function isEqualizerFlat(settings: EqualizerSettings): boolean {
+  return settings.preampDb === 0 && settings.bandsDb.every((gain) => gain === 0);
+}
+
+/** Whether the selected engine can apply it at all. */
+export function isEqualizerAvailable(): boolean {
+  return usesRustAudioEngine();
+}
+
+function push(settings: EqualizerSettings): void {
+  void invoke("native_audio_set_equalizer", {
+    preampDb: settings.preampDb,
+    bandsDb: settings.bandsDb,
+  }).catch((error: unknown) => {
+    logInternalWarn("Equalizer push failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  });
+}
+
+export function getEqualizer(): EqualizerSettings {
+  return readSettings();
+}
+
+export function setEqualizer(settings: EqualizerSettings): void {
+  const clamped: EqualizerSettings = {
+    preampDb: clamp(settings.preampDb),
+    bandsDb: settings.bandsDb.map(clamp),
+  };
+  cached = clamped;
+  writeLocalJsonSetting(STORAGE_KEY, clamped);
+  // Before the event, so a component that reads back on the change already sees it applied.
+  push(clamped);
+  window.dispatchEvent(new Event(CHANGE_EVENT));
+}
+
+function clamp(gain: number): number {
+  if (!Number.isFinite(gain)) return 0;
+  return Math.min(EQUALIZER_MAX_DB, Math.max(-EQUALIZER_MAX_DB, gain));
+}
+
+function subscribe(callback: () => void) {
+  window.addEventListener(CHANGE_EVENT, callback);
+  window.addEventListener("storage", callback);
+  return () => {
+    window.removeEventListener(CHANGE_EVENT, callback);
+    window.removeEventListener("storage", callback);
+  };
+}
+
+if (typeof window !== "undefined") {
+  window.addEventListener("storage", () => {
+    cached = null;
+  });
+}
+
+export async function hydrateEqualizer(): Promise<void> {
+  await hydrateLocalJsonSetting(STORAGE_KEY, isEqualizerSettings);
+  cached = null;
+  /*
+   * Rust starts flat every launch — the values are process state, not a file — so the stored
+   * settings have to be pushed down or the equaliser silently does nothing until the user
+   * touches a slider.
+   */
+  push(readSettings());
+  window.dispatchEvent(new Event(CHANGE_EVENT));
+}
+
+export function useEqualizer(): EqualizerSettings {
+  return useSyncExternalStore(subscribe, readSettings, () => EQUALIZER_FLAT);
+}


### PR DESCRIPTION
Playback moves into Rust: symphonia demuxes, libopus decodes, cpal plays. The hidden `youtube.com` frame is gone by default.

- New `rust` audio engine, now the default. Two decks, so gapless and crossfade work — including on downloads and local files, which never had them.
- IFrame deck kept as a per-track fallback when a stream is refused, so a 403 is no longer a dead track.
- Opus decoded via libopus; symphonia has no Opus decoder.
- Ten-band equaliser with presets, preamp and a limiter. Rust engine only.
- Media server released when the Rust engine takes over; never started at all from a cold start.
- Fixed: concurrent range fills raced and got 403s (`PLAYBACK_FILL_LOCK`).
- Fixed: `toTrack` turned podcast browse ids into unplayable tracks.
- Fixed: stored audio routed by declared mime type instead of its own bytes.
- Fixed: Opus duration read as samples rather than through the container time base.
- Build deps added: cmake (libopus) and ALSA on Linux (cpal). In `ci.yml`, `release.yml` and the AUR PKGBUILD.

Version 1.3.0. Merging to main triggers the release workflow.