### PR TITLE
fix: delete YouTube Music playlists via direct API endpoint

### DIFF
--- a/src/datasource/youtube/YouTubeMusicDataSource.ts
+++ b/src/datasource/youtube/YouTubeMusicDataSource.ts
@@ -3891,9 +3891,15 @@ export class YouTubeMusicDataSource extends DataSource {
     }
 
     const client = await this.getMusicClient();
-    await client.playlist.delete(this.editablePlaylistId(playlist.id));
+    const playlistId = this.editablePlaylistId(playlist.id);
+    // youtubei.js 17.0.1's playlist.delete() loses this endpoint's API path and throws
+    // "Expected an api_url" before sending a request, so execute the same mutation directly.
+    const response = await client.actions.execute("playlist/delete", { playlistId });
+    if (!response.success) {
+      throw new Error(`Playlist deletion returned HTTP ${response.status_code}.`);
+    }
     await setCachedJson(this.getPlaylistTrackCacheKey(playlist.id), []);
-    logInternalInfo("YouTubeMusicDataSource.deletePlaylist", { playlistId: playlist.id });
+    logInternalInfo("YouTubeMusicDataSource.deletePlaylist", { playlistId });
   }
 
   /**


### PR DESCRIPTION
## What and why

Use a direct API call because youtubei.js is broken

Closes #37

## How it was checked

<!-- Delete what does not apply. -->

- [X] `npm run verify` passes
- [X] Ran the app and used the affected screen
<img width="194" height="123" alt="image" src="https://github.com/user-attachments/assets/84a34b66-f7f8-4f81-bb18-f2cd0a0e0be8" />
