### PR TITLE
fix(ui): fix text highlighting direction for Arabic (RTL)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zuno",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zuno",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "dependencies": {
         "@fontsource-variable/inter": "^5.3.0",
         "@solar-icons/react": "^2.0.0-beta.0",

--- a/package.json
+++ b/package.json
@@ -39,8 +39,5 @@
     "tailwindcss": "^4.3.3",
     "typescript": "~5.8.3",
     "vite": "^7.0.4"
-  },
-  "allowScripts": {
-    "esbuild@0.28.1": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,5 +39,8 @@
     "tailwindcss": "^4.3.3",
     "typescript": "~5.8.3",
     "vite": "^7.0.4"
+  },
+  "allowScripts": {
+    "esbuild@0.28.1": true
   }
 }

--- a/src/ui/pages/LyricsView.tsx
+++ b/src/ui/pages/LyricsView.tsx
@@ -659,6 +659,9 @@ const SyncedLine = memo(function SyncedLine({
     [index, register],
   );
 
+  // Check if there's letters
+  const isArabic = /[\u0600-\u06FF]/.test(text);
+
   // An empty LRC line is a real instrumental beat, not junk. It keeps its slot so the timing
   // stays honest, and announces itself when it comes up.
   if (!text.trim()) {
@@ -687,6 +690,8 @@ const SyncedLine = memo(function SyncedLine({
     <button
       ref={attach}
       type="button"
+      // The direction of the language
+      dir={isArabic ? "rtl" : "ltr"}
       tabIndex={isTabbable ? 0 : -1}
       aria-current={isActive ? "true" : undefined}
       onFocus={() => onFocusLine(index)}

--- a/src/ui/pages/LyricsView.tsx
+++ b/src/ui/pages/LyricsView.tsx
@@ -695,8 +695,9 @@ const SyncedLine = memo(function SyncedLine({
       tabIndex={isTabbable ? 0 : -1}
       aria-current={isActive ? "true" : undefined}
       onFocus={() => onFocusLine(index)}
+      // Using (text-start) instead of (text-left)
       className={cn(
-        "group relative origin-left text-pretty text-left font-bold leading-[1.16] tracking-[-0.035em]",
+        "group relative origin-left text-pretty text-start font-bold leading-[1.16] tracking-[-0.035em]",
         "transition-[opacity,filter,color] duration-500 ease-out",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
         /*
@@ -716,10 +717,13 @@ const SyncedLine = memo(function SyncedLine({
     >
       {/* The one piece of brand colour on the screen, and the only thing marking which line
           is playing when the sweep is at either end. */}
+      
+      {/* Posistion the highlight indicator on the right for Arabic (RTL), and on the left for (LTR) Languages */}
       <span
         aria-hidden="true"
         className={cn(
-          "absolute -left-5 top-[0.28em] h-[0.72em] w-[3px] rounded-full bg-primary transition-opacity duration-300",
+          "absolute top-[0.28em] h-[0.72em] w-[3px] rounded-full bg-primary transition-opacity duration-300",
+          isArabic ? "-right-5" : "-left-5",
           isActive ? "opacity-100" : "opacity-0 group-hover:opacity-40",
         )}
       />

--- a/src/ui/styles/global.css
+++ b/src/ui/styles/global.css
@@ -394,6 +394,17 @@ html[data-platform-linux] *::after {
   -webkit-text-fill-color: transparent;
 }
 
+/* For RTL Arabic language */
+[dir="rtl"] .lyric-sweep,
+.lyric-sweep[dir="rtl"],
+.lyric-sweep:dir(rtl) {
+  background-image: linear-gradient(
+    270deg,
+    var(--color-foreground) calc(var(--sweep, 0%) - 4%),
+    color-mix(in oklab, var(--color-foreground) 28%, transparent) calc(var(--sweep, 0%) + 7%)
+  );
+}
+
 /*
  * Slow parallax on the blurred cover behind the lyrics. Long and asymmetric on purpose: at
  * 44s nothing ever appears to move while you read, but the backdrop is never twice the same,


### PR DESCRIPTION
## What and why

Fixed Arabic synced lyrics text highlighting direction to render Right-to-Left (RTL) instead of LTR for proper visual alignment (Highlighting)

## How it was checked

<!-- Delete what does not apply. -->

- [x] Ran the app and used the affected screen

## Notes for the reviewer

Try the song: Shoft Kalam by Marawn Pablo
