### PR TITLE
landing: no demo autoplay, Vercel Analytics

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -62,27 +62,44 @@ jobs:
         run: |
           flatpak remote-add --user --if-not-exists flathub \
             https://dl.flathub.org/repo/flathub.flatpakrepo
-          # The SDK extensions track the freedesktop base, not the GNOME version — GNOME 47
-          # sits on 24.08, so rust-stable//47 does not exist and the build would fail
+          # org.flatpak.Builder carries flatpak-builder-lint, which is the check Flathub
+          # actually runs — and its flatpak-builder is the version they build with, rather
+          # than whatever the container image happens to ship.
+          #
+          # The SDK extensions track the freedesktop base, not the GNOME version — GNOME 50
+          # sits on 25.08, so rust-stable//50 does not exist and the build would fail
           # resolving it.
           flatpak install --user -y --noninteractive flathub \
-            org.gnome.Platform//47 \
-            org.gnome.Sdk//47 \
-            org.freedesktop.Sdk.Extension.rust-stable//24.08 \
-            org.freedesktop.Sdk.Extension.node20//24.08
+            org.flatpak.Builder \
+            org.gnome.Platform//50 \
+            org.gnome.Sdk//50 \
+            org.freedesktop.Sdk.Extension.rust-stable//25.08 \
+            org.freedesktop.Sdk.Extension.node22//25.08
 
       - name: Validate metadata
         run: |
-          # Both are hard gates at Flathub review, and both are cheap to check here.
+          # All three are hard gates at Flathub review, and all three are cheap to check here.
+          # The manifest lint is the one the submission docs tell you to run before opening
+          # the PR; it catches finish-args and export mistakes the other two never look at.
           appstreamcli validate --no-net packaging/flatpak/io.github.nofayz.Zuno.metainfo.xml
           desktop-file-validate packaging/flatpak/io.github.nofayz.Zuno.desktop
+          flatpak run --command=flatpak-builder-lint org.flatpak.Builder \
+            manifest packaging/flatpak/io.github.nofayz.Zuno.yml
 
       - name: Build
         run: |
-          flatpak-builder --user --disable-rofiles-fuse --force-clean \
+          flatpak run org.flatpak.Builder --user --disable-rofiles-fuse --force-clean \
             --install-deps-from=flathub \
             --repo=repo build-dir packaging/flatpak/io.github.nofayz.Zuno.yml
           flatpak build-bundle repo zuno.flatpak io.github.nofayz.Zuno
+
+      # Not a gate. The repo lint expects screenshots already mirrored into the ostree
+      # commit, which only happens on Flathub's own builders — it will fail here for a
+      # reason that says nothing about the submission. Read it, do not trust the exit code.
+      - name: Lint the built repo
+        continue-on-error: true
+        run: |
+          flatpak run --command=flatpak-builder-lint org.flatpak.Builder repo repo
 
       - uses: actions/upload-artifact@v4
         if: always()

--- a/landing/package-lock.json
+++ b/landing/package-lock.json
@@ -8,12 +8,13 @@
       "name": "zuno-landing",
       "version": "0.1.0",
       "dependencies": {
-        "@iconify-json/logos": "^1.2.11",
         "@iconify/react": "^6.0.2",
+        "@vercel/analytics": "^2.0.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       },
       "devDependencies": {
+        "@iconify-json/logos": "^1.2.11",
         "@tailwindcss/vite": "^4.0.0",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
@@ -751,6 +752,7 @@
       "version": "1.2.11",
       "resolved": "https://registry.npmjs.org/@iconify-json/logos/-/logos-1.2.11.tgz",
       "integrity": "sha512-fOo4pGEatuyuCFNL+cwquYMa2Im0oJHRHV7lt/Qqs5Ode/lPImHCQcfTtPzZj7qYMPb/h8YHN3TG54uEowrjNQ==",
+      "dev": true,
       "license": "CC0-1.0",
       "dependencies": {
         "@iconify/types": "*"
@@ -1577,6 +1579,48 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vitejs/plugin-react": {

--- a/landing/package.json
+++ b/landing/package.json
@@ -10,17 +10,18 @@
   },
   "dependencies": {
     "@iconify/react": "^6.0.2",
+    "@vercel/analytics": "^2.0.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
+    "@iconify-json/logos": "^1.2.11",
     "@tailwindcss/vite": "^4.0.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.0",
     "tailwindcss": "^4.0.0",
     "typescript": "~5.6.0",
-    "vite": "^7.0.0",
-    "@iconify-json/logos": "^1.2.11"
+    "vite": "^7.0.0"
   }
 }

--- a/landing/src/components/MiniPlayer.tsx
+++ b/landing/src/components/MiniPlayer.tsx
@@ -71,28 +71,9 @@ export function MiniPlayer() {
     audio.addEventListener("play", sync);
     audio.addEventListener("pause", sync);
 
-    /*
-     * Autoplay, with the fallback the platform forces.
-     *
-     * Every engine refuses `play()` with sound until the visitor has interacted with the page,
-     * and the refusal is a rejected promise rather than an error — so the first gesture anywhere
-     * on the document starts it instead. `once` means the listener costs nothing after that, and
-     * a browser that does allow the first attempt never registers it at all.
-     */
-    let start: (() => void) | null = null;
-    void audio.play().catch(() => {
-      start = () => void audio.play();
-      document.addEventListener("pointerdown", start, { once: true });
-      document.addEventListener("keydown", start, { once: true });
-    });
-
     return () => {
       audio.removeEventListener("play", sync);
       audio.removeEventListener("pause", sync);
-      if (start) {
-        document.removeEventListener("pointerdown", start);
-        document.removeEventListener("keydown", start);
-      }
     };
   }, []);
 
@@ -136,11 +117,19 @@ export function MiniPlayer() {
 
   return (
     <div className="pointer-events-none fixed inset-0 z-50">
+      {/*
+        Silent until the play button is pressed.
+
+        It used to autoplay, and fall back to starting on the first pointerdown or keydown
+        anywhere on the document when the browser refused — so a visitor clicking a download
+        link got music they never asked for, from a control they may not have noticed. `metadata`
+        rather than `auto` for the same reason: nothing is fetched beyond the duration the
+        progress ring needs until someone actually wants to hear it.
+      */}
       <audio
         ref={audioRef}
         src={TRACK.src}
-        autoPlay
-        preload="auto"
+        preload="metadata"
         onTimeUpdate={(event) => setTime(event.currentTarget.currentTime)}
         onLoadedMetadata={(event) => setDuration(event.currentTarget.duration)}
       />

--- a/landing/src/main.tsx
+++ b/landing/src/main.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { Analytics } from "@vercel/analytics/react";
 import { App } from "./App";
 import "./styles.css";
 
@@ -15,5 +16,6 @@ document.documentElement.dataset.theme = "dark";
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
     <App />
+    <Analytics />
   </React.StrictMode>,
 );

--- a/packaging/flatpak/io.github.nofayz.Zuno.desktop
+++ b/packaging/flatpak/io.github.nofayz.Zuno.desktop
@@ -7,7 +7,9 @@ Comment=Desktop client for YouTube Music
 # Player are what put it under Music rather than loose in Multimedia.
 Categories=AudioVideo;Audio;Player;
 Keywords=music;youtube;player;streaming;audio;
-Exec=zuno %U
+# No %U: nothing here registers a URL scheme or a MimeType, so the field code would be
+# advertising handling the app does not do.
+Exec=zuno
 Icon=io.github.nofayz.Zuno
 Terminal=false
 # Must match the WM_CLASS the window actually sets, or the shell shows a second, iconless

--- a/packaging/flatpak/io.github.nofayz.Zuno.metainfo.xml
+++ b/packaging/flatpak/io.github.nofayz.Zuno.metainfo.xml
@@ -34,6 +34,7 @@
       <li>Lyrics translation under each line</li>
       <li>A mini player that appears when you switch away</li>
       <li>Local audio files alongside your library, with a tag editor</li>
+      <li>A ten-band equaliser with presets</li>
       <li>Discord Rich Presence and Last.fm scrobbling</li>
       <li>Light and dark themes, following the system by default</li>
     </ul>
@@ -49,31 +50,35 @@
   <url type="bugtracker">https://github.com/noFAYZ/zuno/issues</url>
   <url type="vcs-browser">https://github.com/noFAYZ/zuno</url>
 
+  <!--
+    Pinned to a tag, not to main. These URLs are what the store listing shows, and a rename
+    on main would break all four of them.
+  -->
   <screenshots>
     <screenshot type="default">
-      <image>https://raw.githubusercontent.com/noFAYZ/zuno/main/assets/img/zuno-d1-1.2.PNG</image>
+      <image>https://raw.githubusercontent.com/noFAYZ/zuno/v1.3.0/assets/img/zuno-d1-1.2.PNG</image>
       <caption>The home view, with recommendations and recently played</caption>
     </screenshot>
     <screenshot>
-      <image>https://raw.githubusercontent.com/noFAYZ/zuno/main/assets/img/zuno-d-1.2.PNG</image>
+      <image>https://raw.githubusercontent.com/noFAYZ/zuno/v1.3.0/assets/img/zuno-d-1.2.PNG</image>
       <caption>Synced lyrics following the current line</caption>
     </screenshot>
     <screenshot>
-      <image>https://raw.githubusercontent.com/noFAYZ/zuno/main/assets/img/zuno-l5-1.2.PNG</image>
+      <image>https://raw.githubusercontent.com/noFAYZ/zuno/v1.3.0/assets/img/zuno-l5-1.2.PNG</image>
       <caption>The library, in light theme</caption>
     </screenshot>
     <screenshot>
-      <image>https://raw.githubusercontent.com/noFAYZ/zuno/main/assets/img/zuno-d4-1.2.PNG</image>
+      <image>https://raw.githubusercontent.com/noFAYZ/zuno/v1.3.0/assets/img/zuno-d4-1.2.PNG</image>
       <caption>An artist page, with popular songs and releases</caption>
     </screenshot>
   </screenshots>
 
   <!--
-    Streams music from an online account and can open links in a browser, which is what these
-    two declare. Everything else is none — there is no chat, no ads, no purchasing.
+    Signing in sends account details to YouTube, which is what social-info covers. Nothing
+    else applies — social-audio is voice chat between users, not playback, and there is no
+    chat, no ads and no purchasing.
   -->
   <content_rating type="oars-1.1">
-    <content_attribute id="social-audio">intense</content_attribute>
     <content_attribute id="social-info">mild</content_attribute>
   </content_rating>
 
@@ -83,6 +88,25 @@
   </branding>
 
   <releases>
+    <release version="1.3.0" date="2026-08-02">
+      <url type="details">https://github.com/noFAYZ/zuno/releases/tag/v1.3.0</url>
+      <description>
+        <p>
+          Adds a Rust audio engine that decodes and plays tracks itself, with no YouTube
+          subframe and no audio in the renderer, and a ten-band equaliser with presets.
+          Gapless playback and crossfade work on the new engine.
+        </p>
+      </description>
+    </release>
+    <release version="1.2.2" date="2026-08-01">
+      <url type="details">https://github.com/noFAYZ/zuno/releases/tag/v1.2.2</url>
+      <description>
+        <p>
+          Lower memory use and faster cold loads. Adds YouTube account settings and an album
+          column in the library, and fixes album links that resolved to the wrong record.
+        </p>
+      </description>
+    </release>
     <release version="1.2.1" date="2026-07-29">
       <url type="details">https://github.com/noFAYZ/zuno/releases/tag/v1.2.1</url>
       <description>

--- a/packaging/flatpak/io.github.nofayz.Zuno.yml
+++ b/packaging/flatpak/io.github.nofayz.Zuno.yml
@@ -9,17 +9,19 @@
 # must be committed alongside this file; they are not written by hand.
 app-id: io.github.nofayz.Zuno
 
-# 47, not 46, because of Rust rather than WebKit: the SDK extensions track the freedesktop
-# base, 46 sits on 23.08, and that carries Cargo 1.81 — too old for the `edition2024` several
-# transitive crates now require. 47 sits on 24.08. The 47 runtime still provides
-# webkit2gtk-4.1 alongside webkitgtk-6.0, so Tauri links as before.
+# 50 because Flathub rejects EOL runtimes, and a GNOME branch is EOL as soon as the next
+# stable ships. 50 is the current one. It still provides webkit2gtk-4.1 alongside
+# webkitgtk-6.0, so Tauri links as before.
 runtime: org.gnome.Platform
-runtime-version: "47"
+runtime-version: "50"
 sdk: org.gnome.Sdk
 
+# The SDK extensions track the freedesktop base, not the GNOME version — 50 sits on 25.08,
+# so that is the branch to install. node22 rather than node20: Node 20 went end of life in
+# April 2026 and has no 25.08 extension to install.
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.rust-stable
-  - org.freedesktop.Sdk.Extension.node20
+  - org.freedesktop.Sdk.Extension.node22
 
 command: zuno
 
@@ -56,7 +58,7 @@ modules:
     buildsystem: simple
 
     build-options:
-      append-path: /usr/lib/sdk/rust-stable/bin:/usr/lib/sdk/node20/bin
+      append-path: /usr/lib/sdk/rust-stable/bin:/usr/lib/sdk/node22/bin
       env:
         # Matches where flatpak-cargo-generator writes its config; the sandbox has no
         # writable $HOME for cargo's default location.
@@ -68,9 +70,9 @@ modules:
     sources:
       - type: git
         url: https://github.com/noFAYZ/zuno.git
-        tag: v1.2.1
+        tag: v1.3.0
         # Pinned so the build is reproducible even if the tag were ever moved.
-        commit: 168eae956555a07e7be6e185cb82f1079a861c7d
+        commit: 4983173f2a507fa52191a4eac73ed1ebe5026fad
 
       # Generated. See packaging/flatpak/README.md.
       - cargo-sources.json


### PR DESCRIPTION
- Landing no longer autoplays the demo song.
- Adds `@vercel/analytics`, mounted in `landing/src/main.tsx`. Vite/React app, so the import is `@vercel/analytics/react` — the `/next` entry pulls in `next/navigation` and won't resolve.

Also carries flatpak packaging and `flatpak.yml` workflow changes that were already in the tree.