### PR TITLE
Discord RPC: dedupe presence updates

### DIFF
--- a/src/player/DiscordRPC.check.ts
+++ b/src/player/DiscordRPC.check.ts
@@ -1,0 +1,42 @@
+/**
+ * Self-check for the presence dedupe key.
+ *
+ * `PlayerController.emit()` fires on every state change, most of which have nothing to do with
+ * Discord. Getting the key wrong in either direction fails quietly: too narrow and a real track
+ * change stops updating Discord, too wide and every queue reorder goes back to spamming an IPC
+ * call for a payload that already matches what is showing.
+ */
+export {};
+
+import { presenceDedupeKey, type DiscordPresenceData } from "./DiscordRPC";
+
+function check(condition: boolean, message: string): void {
+  if (!condition) throw new Error(`FAILED: ${message}`);
+}
+
+const base: DiscordPresenceData = {
+  title: "Song",
+  artist: "Artist",
+  album: "Album",
+  duration: 200,
+  currentTime: 10,
+  isPlaying: true,
+};
+
+// The whole point: currentTime alone must not change the key.
+check(
+  presenceDedupeKey(base) === presenceDedupeKey({ ...base, currentTime: 45 }),
+  "currentTime is excluded from the key",
+);
+
+// Anything else changing has to produce a different key, or Discord never hears about it.
+check(
+  presenceDedupeKey(base) !== presenceDedupeKey({ ...base, title: "Other song" }),
+  "title change is not deduped away",
+);
+check(
+  presenceDedupeKey(base) !== presenceDedupeKey({ ...base, isPlaying: false }),
+  "play/pause change is not deduped away",
+);
+
+console.log("DiscordRPC.check.ts passed");

--- a/src/player/DiscordRPC.ts
+++ b/src/player/DiscordRPC.ts
@@ -65,6 +65,12 @@ function sanitizePresenceLink(value?: string): string | undefined {
   }
 }
 
+/** Identity of a presence payload for dedupe purposes — everything but `currentTime`. */
+export function presenceDedupeKey(data: DiscordPresenceData): string {
+  const { currentTime: _currentTime, ...rest } = data;
+  return JSON.stringify(rest);
+}
+
 function sanitizePresenceData(data: DiscordPresenceData): DiscordPresenceData {
   return {
     title: sanitizeDiscordText(data.title),
@@ -94,6 +100,18 @@ export class DiscordRpcService {
   }
 
   /**
+   * The last payload actually sent, everything but `currentTime`.
+   *
+   * `PlayerController.emit()` fires on every state change — a queue reorder, a rate change, a
+   * sleep timer — most of which leave the track and play state untouched. Discord runs its own
+   * clock off the timestamps `discord_rpc.rs` derives from `currentTime`, so it never needed
+   * repolling either; comparing on everything else and always excluding `currentTime` is what
+   * turns those into no-ops instead of a fresh IPC round trip (and a jittered progress bar) on
+   * every unrelated change.
+   */
+  private static lastSentKey: string | null = null;
+
+  /**
    * Initialize Discord RPC
    * The actual connection happens on the Rust backend
    */
@@ -114,6 +132,7 @@ export class DiscordRpcService {
 
     try {
       await invoke("discord_rpc_clear");
+      this.lastSentKey = null;
       logInternalDebug("Discord.setEnabled cleared presence", {});
     } catch (error) {
       logInternalWarn("Discord.setEnabled.clearFailed", error as Record<string, unknown>);
@@ -129,8 +148,11 @@ export class DiscordRpcService {
       return;
     }
 
+    const safeData = sanitizePresenceData(data);
+    const nextKey = presenceDedupeKey(safeData);
+    if (nextKey === this.lastSentKey) return;
+
     try {
-      const safeData = sanitizePresenceData(data);
       logInternalDebug("Discord.updatePresence", {
         title: safeData.title,
         artist: safeData.artist,
@@ -151,6 +173,7 @@ export class DiscordRpcService {
         isPlaying: safeData.isPlaying,
       });
 
+      this.lastSentKey = nextKey;
       logInternalDebug("Discord.updatePresence.success", {});
     } catch (error) {
       logInternalWarn("Discord.updatePresence.failed", error as Record<string, unknown>);
@@ -167,6 +190,9 @@ export class DiscordRpcService {
     try {
       logInternalDebug("Discord.clearPresence", {});
       await invoke("discord_rpc_clear");
+      // The next real track has to go out even if it matches whatever was showing before
+      // the clear.
+      this.lastSentKey = null;
       logInternalDebug("Discord.clearPresence.success", {});
     } catch (error) {
       logInternalWarn("Discord.clearPresence.failed", error as Record<string, unknown>);


### PR DESCRIPTION
Discord RPC was wired into `PlayerController.emit()`, which fires on every state change (queue edits, rate, sleep timer, …) — each one sent a full `discord_rpc_update` IPC call with no dedupe on either end, even when nothing Discord shows had changed. Last.fm and MPRIS/SMTC were already properly gated; this brings Discord in line.

Adds a dedupe key over everything but `currentTime`. Cleared on disable/clear so the next real track always goes out.