### PR TITLE
Warm the YouTube download client + PO token after library load

### DIFF
--- a/src/datasource/DataSource.ts
+++ b/src/datasource/DataSource.ts
@@ -61,6 +61,13 @@ export abstract class DataSource {
   getSearchSuggestions?(query: string, onUpdate?: (suggestions: string[]) => void): Promise<string[]>;
   getStreamData?(track: Track): Promise<StreamData>;
   /**
+   * Pre-pays whatever first-play latency can be paid before there is a play — e.g. warming a
+   * lazily-created client or a slow one-time attestation. Fire-and-forget: called when the
+   * source is otherwise idle, never awaited, and a failure must silently leave the ordinary
+   * lazy path to cover it on the first real request.
+   */
+  warmPlayback?(): void;
+  /**
    * Reports plays to the provider's own listening history.
    *
    * Optional and best-effort on both sides: a source that has no such concept simply omits

--- a/src/datasource/youtube/YouTubeMusicDataSource.ts
+++ b/src/datasource/youtube/YouTubeMusicDataSource.ts
@@ -13,7 +13,7 @@ import { ClientType, Innertube, Platform, Types, YTNodes } from "youtubei.js";
 import { getAppSetting, removeAppSetting, setAppSetting } from "../../internal/appSettings";
 import { clearCache, getCachedJson, setCachedJson } from "../../internal/cache";
 import { logInternalDebug, logInternalError, logInternalInfo, logInternalWarn } from "../../internal/logging";
-import { mintPoToken } from "./poToken";
+import { mintPoToken, warmPoToken } from "./poToken";
 import { AuthExpiredError, DataSource, type StreamData } from "../DataSource";
 import type {
   AccountOption,
@@ -551,6 +551,28 @@ export class YouTubeMusicDataSource extends DataSource {
     }
 
     return this.downloadClientPromise;
+  }
+
+  /**
+   * Pre-creates the download client and pre-runs the BotGuard attestation, off the critical
+   * path.
+   *
+   * Both are otherwise paid in full the instant someone presses play for the first time in a
+   * session: `getDownloadClient` re-fetches assets `getMusicClient` already warmed (its own
+   * session, its own player script) because it deliberately cannot share that client's identity
+   * — see the comment above — and `warmPoToken` is the ~3s BotGuard challenge. Together they
+   * were the first play's entire 6+ seconds. Calling this once the library has already loaded
+   * moves that cost into idle time instead of the moment someone is waiting on sound; both calls
+   * are independently memoized, so a second call (or the ordinary lazy path beating this to it)
+   * costs nothing extra.
+   */
+  warmPlayback(): void {
+    void this.getDownloadClient().catch((error) => {
+      logInternalWarn("YouTubeMusicDataSource.warmPlayback download client failed", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+    warmPoToken();
   }
 
   /**
@@ -3118,6 +3140,10 @@ export class YouTubeMusicDataSource extends DataSource {
       onBehalfOfUser: this.musicOnBehalfOfUser,
       accountName: this.musicAccountName,
     });
+
+    // The library is the last thing the app was already fetching for the user; whatever
+    // bandwidth/CPU first play would otherwise need is free from here until they press play.
+    this.warmPlayback();
 
     return {
       account: {

--- a/src/datasource/youtube/poToken.ts
+++ b/src/datasource/youtube/poToken.ts
@@ -125,6 +125,23 @@ function getMinter(): Promise<CachedMinter> {
 }
 
 /**
+ * Runs the BotGuard challenge ahead of the first play, off the critical path.
+ *
+ * `attest()` is the ~3s half of first-play latency — a fixed Google-side cost, paid once and
+ * cached for `getMinter`'s TTL regardless of when it runs. Calling this while the app is
+ * otherwise idle (after the library loads) means the first `mintPoToken` call finds the minter
+ * already warm instead of blocking playback on it. Errors are swallowed: a failed pre-attest
+ * just leaves `mintPoToken` to try again, exactly as if this had never been called.
+ */
+export function warmPoToken(): void {
+  void getMinter().catch((error) => {
+    logInternalWarn("poToken.warm failed", {
+      message: error instanceof Error ? error.message : String(error),
+    });
+  });
+}
+
+/**
  * Mints a PO token bound to `contentBinding` — a visitor ID for session tokens, a video ID for
  * per-content ones.
  *


### PR DESCRIPTION
First play measured ~6.3s cold: `getDownloadClient` re-fetches assets `getMusicClient` already has (it needs its own network-issued visitor ID, can't share the music client's), and `mintPoToken`'s BotGuard attestation is a ~3s one-time challenge. Both are memoized and track-independent, they just never ran until the moment someone pressed play.

Adds `DataSource.warmPlayback?()`; the YouTube source fires both in parallel once the library load resolves, the app's first idle point. Fire-and-forget — a failure leaves the existing lazy path to cover it, same as today.