### PR TITLE
Fix scrobble-ticker leak and sidebar drag listener churn

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,15 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+/**
+ * `m:ss` for a whole-second duration. Callers round `seconds` themselves (floor for elapsed
+ * position, ceil for a countdown) — this only formats what it's given.
+ */
+export function formatMinutesSeconds(seconds: number): string {
+  if (!Number.isFinite(seconds)) return "0:00";
+  const whole = Math.max(0, Math.floor(seconds));
+  const mins = Math.floor(whole / 60);
+  const secs = whole % 60;
+  return `${mins}:${secs.toString().padStart(2, "0")}`;
+}

--- a/src/player/PlayerController.ts
+++ b/src/player/PlayerController.ts
@@ -1807,6 +1807,7 @@ export class PlayerController {
   suspendForTabSwitch(): void {
     this.isTabActive = false;
     this.syncTransitionTicker();
+    this.syncScrobbleTicker();
     if (this.state.status === "playing") {
       this.audioEngine.suspend();
     }
@@ -1815,6 +1816,7 @@ export class PlayerController {
   async resumeFromTabSwitch(): Promise<void> {
     this.isTabActive = true;
     this.syncTransitionTicker();
+    this.syncScrobbleTicker();
     if (this.state.status !== "playing" || !this.state.currentTrack) return;
 
     try {
@@ -1831,6 +1833,7 @@ export class PlayerController {
     this.flushPlaybackSettings();
     this.isTabActive = false;
     this.syncTransitionTicker();
+    this.syncScrobbleTicker();
     this.audioEngine.setOnEnded(null);
     this.audioEngine.dispose();
     this.listeners.clear();

--- a/src/ui/components/Sidebar.tsx
+++ b/src/ui/components/Sidebar.tsx
@@ -493,6 +493,16 @@ export function Sidebar({
   const filterInputRef = useRef<HTMLInputElement | null>(null);
   const [draggedItem, setDraggedItem] = useState<{ id: string; type: LibraryView } | null>(null);
   const [dropTarget, setDropTarget] = useState<{ id: string; type: LibraryView; insertAfter: boolean } | null>(null);
+  /*
+   * Read inside the window listener instead of closing over the `dropTarget` state — see
+   * QueuePanel's identical ref for why: with the state itself in the effect's deps, every
+   * drop-target change during a drag (near-continuous while crossing rows) tore the three
+   * window listeners down and rebuilt them, rather than the effect running once per drag.
+   */
+  const dropTargetRef = useRef(dropTarget);
+  dropTargetRef.current = dropTarget;
+  const playlistOrderRef = useRef(playlistOrder);
+  playlistOrderRef.current = playlistOrder;
   const localPlaylists = useSyncExternalStore(
     subscribeToLocalPlaylists,
     getLocalPlaylistItems,
@@ -938,30 +948,35 @@ export function Sidebar({
       }
 
       const bounds = targetElement.getBoundingClientRect();
-      setDropTarget({
-        id: targetId,
-        type: targetType,
-        insertAfter: event.clientY >= bounds.top + bounds.height / 2,
-      });
+      const insertAfter = event.clientY >= bounds.top + bounds.height / 2;
+      // Same target as last frame: skip the state write. A drag holds mostly still over one
+      // row between boundary crossings, and each write was a re-render plus (see below) a
+      // teardown/rebuild of these very listeners.
+      const current = dropTargetRef.current;
+      if (current?.id === targetId && current.type === targetType && current.insertAfter === insertAfter) {
+        return;
+      }
+      setDropTarget({ id: targetId, type: targetType, insertAfter });
     };
 
     const handlePointerUp = (event: PointerEvent) => {
       const drag = pointerDragRef.current;
       if (!drag || event.pointerId !== drag.pointerId) return;
 
-      if (drag.isDragging && dropTarget && dropTarget.type === drag.itemType && dropTarget.id !== drag.itemId) {
+      const drop = dropTargetRef.current;
+      if (drag.isDragging && drop && drop.type === drag.itemType && drop.id !== drag.itemId) {
         const currentIds =
           drag.itemType === "playlists" ? playlistsRef.current : albumsRef.current;
         const nextOrder = reorderIds(
           currentIds,
           drag.itemId,
-          dropTarget.id,
-          dropTarget.insertAfter,
+          drop.id,
+          drop.insertAfter,
         );
 
         if (drag.itemType === "playlists") {
           const nextPlaylistOrder = mergeVisibleOrderWithStoredOrder(
-            playlistOrder,
+            playlistOrderRef.current,
             nextOrder,
           );
           setPlaylistOrder(nextPlaylistOrder);
@@ -1005,7 +1020,7 @@ export function Sidebar({
       window.removeEventListener("pointerup", handlePointerUp);
       window.removeEventListener("pointercancel", handlePointerUp);
     };
-  }, [dropTarget, playlistOrder]);
+  }, []);
 
   const totalLibraryCount = libraryView === "albums" ? albums.length : playlists.length;
   const activeSortLabel =

--- a/src/ui/components/player/PlaybackOptions.tsx
+++ b/src/ui/components/player/PlaybackOptions.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { cn } from "@/lib/utils";
+import { cn, formatMinutesSeconds } from "@/lib/utils";
 import { Tooltip } from "@/components/motion/tooltip";
 import { ClockIcon, SpeedIcon } from "@/ui/icons";
 import { playerController } from "../../../player/playerStore";
@@ -11,12 +11,8 @@ const SPEEDS = [0.75, 1, 1.25, 1.5, 2] as const;
 /** Sleep durations, plus "end of track" which is handled separately. */
 const SLEEP_MINUTES = [15, 30, 45, 60, 90] as const;
 
-function formatCountdown(remainingMs: number): string {
-  const totalSeconds = Math.ceil(remainingMs / 1000);
-  const minutes = Math.floor(totalSeconds / 60);
-  const seconds = totalSeconds % 60;
-  return `${minutes}:${seconds.toString().padStart(2, "0")}`;
-}
+// Ceil, not floor: a countdown showing 0:00 while a second is still running reads as stuck.
+const formatCountdown = (remainingMs: number) => formatMinutesSeconds(Math.ceil(remainingMs / 1000));
 
 /**
  * Playback speed and sleep timer, behind one control.

--- a/src/ui/components/player/SeekBar.tsx
+++ b/src/ui/components/player/SeekBar.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { shallowEqual, usePlayerSelector } from "../../../player/playerStore";
 import { playerController } from "../../../player/playerStore";
 import { playerUIStore, usePlayerUIState } from "../../stores/playerUIStore";
+import { formatMinutesSeconds } from "@/lib/utils";
 
 /*
  * Deliberately NOT beUI's RangeSlider: that component snaps to discrete steps, while
@@ -34,12 +35,7 @@ const TIME_COMMIT_THRESHOLD_S = 0.2;
 /** Poll period when playback is not advancing — see the frame loop below. */
 const IDLE_POLL_MS = 250;
 
-function formatTime(seconds: number): string {
-  if (isNaN(seconds) || !isFinite(seconds)) return "0:00";
-  const mins = Math.floor(seconds / 60);
-  const secs = Math.floor(seconds % 60);
-  return `${mins}:${secs.toString().padStart(2, "0")}`;
-}
+const formatTime = formatMinutesSeconds;
 
 export function SeekBar() {
   const state = usePlayerSelector(


### PR DESCRIPTION
- Scrobble ticker wasn't resynced on tab suspend/resume/dispose, leaving it running against paused or disposed tabs.
- Sidebar drag-reorder rebuilt its window listeners on every pointermove; matched QueuePanel's existing fix.
- Deduped the m:ss formatter shared by SeekBar and PlaybackOptions.