### PR TITLE
Fix remaining artist avatar flakiness after PR #67

### DIFF
--- a/src/datasource/youtube/YouTubeMusicDataSource.ts
+++ b/src/datasource/youtube/YouTubeMusicDataSource.ts
@@ -348,6 +348,15 @@ const SELECTED_ACCOUNT_STORAGE_KEY = "youtube-music:selected-account";
 // v7: artist pictures come from named header fields now — foreground, then thumbnail, then the
 // channel avatar — so anything cached under the older shape-and-crop rules has to go.
 const ARTIST_CACHE_VERSION = "v9";
+/**
+ * How long a background artist refresh is skipped after a recent one.
+ *
+ * `getArtist`'s cache-hit path unconditionally queued a full refetch — every section, every
+ * artwork lookup — on every call, so switching to an artist tab and back a few times inside a
+ * minute repeated the entire fetch that many times for data that had not gone anywhere. Not a
+ * hard cache: a revisit past this window still refreshes, same as before.
+ */
+const ARTIST_REFRESH_COOLDOWN_MS = 60_000;
 const ARTIST_SUBSCRIPTION_OVERRIDE_MS = 60_000;
 const PLAYLIST_PAGE_SESSION_TTL_MS = 10 * 60_000;
 const PLAYLIST_TRACK_CACHE_VERSION = "v6";
@@ -403,6 +412,8 @@ export class YouTubeMusicDataSource extends DataSource {
   private readonly searchRefreshPromises = new Map<string, Promise<Track[]>>();
   private readonly mixedSearchRefreshPromises = new Map<string, Promise<SearchResults>>();
   private readonly artistRefreshPromises = new Map<string, Promise<ArtistPage>>();
+  /** See `ARTIST_REFRESH_COOLDOWN_MS`. */
+  private readonly artistRefreshedAt = new Map<string, number>();
   private readonly suggestionRefreshPromises = new Map<string, Promise<string[]>>();
   private readonly recommendationRefreshPromises = new Map<string, Promise<Track[]>>();
   private readonly lyricsRefreshPromises = new Map<string, Promise<Lyrics>>();
@@ -3386,18 +3397,21 @@ export class YouTubeMusicDataSource extends DataSource {
     const cacheKey = this.getArtistCacheKey(artistId);
     const cached = await getCachedJson<ArtistPage>(cacheKey);
     if (cached) {
-      globalThis.setTimeout(() => {
-        void this.refreshArtist(artistId, cacheKey)
-          .then(({ changed, value }) => {
-            if (changed) onUpdate?.(value);
-          })
-          .catch((error) => {
-            logInternalWarn("YouTubeMusicDataSource.getArtist background refresh failed", {
-              artistId,
-              error: error instanceof Error ? error.message : String(error),
+      const refreshedAt = this.artistRefreshedAt.get(artistId) ?? 0;
+      if (Date.now() - refreshedAt >= ARTIST_REFRESH_COOLDOWN_MS) {
+        globalThis.setTimeout(() => {
+          void this.refreshArtist(artistId, cacheKey)
+            .then(({ changed, value }) => {
+              if (changed) onUpdate?.(value);
+            })
+            .catch((error) => {
+              logInternalWarn("YouTubeMusicDataSource.getArtist background refresh failed", {
+                artistId,
+                error: error instanceof Error ? error.message : String(error),
+              });
             });
-          });
-      }, 0);
+        }, 0);
+      }
       return cached;
     }
     return (await this.refreshArtist(artistId, cacheKey)).value;
@@ -3479,6 +3493,10 @@ export class YouTubeMusicDataSource extends DataSource {
   ): Promise<{ changed: boolean; value: ArtistPage }> {
     let refresh = this.artistRefreshPromises.get(artistId);
     if (!refresh) {
+      // Stamped at the start, not after: the cooldown is about not *starting* another of these
+      // too soon, and a slow fetch should not leave the window open for a second one to begin
+      // while the first is still in flight.
+      this.artistRefreshedAt.set(artistId, Date.now());
       refresh = this.fetchArtistFresh(artistId).finally(() => {
         this.artistRefreshPromises.delete(artistId);
       });

--- a/src/ui/components/TrackArtwork.tsx
+++ b/src/ui/components/TrackArtwork.tsx
@@ -32,6 +32,21 @@ interface TrackArtworkProps {
   loading?: "eager" | "lazy";
   retryOnError?: boolean;
   /**
+   * Skips the direct-URL ladder and goes straight to the Rust proxy.
+   *
+   * For a source that's effectively guaranteed to need it anyway — `googleusercontent` artist
+   * portraits refuse the webview's referer far more often than they accept it — walking every
+   * direct candidate first (each a real network round trip that has to fail before the next one
+   * even starts) turns a single avatar into the slowest thing on the page, and worse, into
+   * something that can still be mid-walk if the view unmounts before it finishes: the proxy
+   * fetch itself keeps running and caches its result regardless, so the *next* mount pays
+   * nothing, but this one shows the placeholder for however long the walk had left. One flag
+   * rather than fixing the ladder's speed: everything else on the ladder resolves directly far
+   * more often than not, and racing the proxy against it there would trade a rare slow cover for
+   * a proxy request on every fast one.
+   */
+  preferProxy?: boolean;
+  /**
    * Rendered width in CSS pixels, matching the `size-*` class on `className`.
    *
    * Sets which size variant is requested. Without it the original, full-size image is loaded:
@@ -47,6 +62,7 @@ export function TrackArtwork({
   className,
   iconSize = 24,
   loading = "lazy",
+  preferProxy = false,
   retryOnError = false,
   size,
   variant = "track",
@@ -74,8 +90,10 @@ export function TrackArtwork({
     if (!artworkUrl?.trim()) return [];
     const cached = cacheKey ? getResolvedArtworkUrl(cacheKey) : undefined;
     if (cached) return [cached];
-    return isLocalArtwork ? [] : getArtworkUrlCandidates(artworkUrl, sizeBucket);
-  }, [artworkUrl, cacheKey, isLocalArtwork, sizeBucket]);
+    // Empty candidates is what already makes embedded artwork skip straight to the proxy
+    // effect below — preferProxy asks for the exact same shortcut for a remote URL.
+    return isLocalArtwork || preferProxy ? [] : getArtworkUrlCandidates(artworkUrl, sizeBucket);
+  }, [artworkUrl, cacheKey, isLocalArtwork, preferProxy, sizeBucket]);
   const [artworkIndex, setArtworkIndex] = useState(0);
   const [retryCount, setRetryCount] = useState(0);
   const [proxiedArtworkUrl, setProxiedArtworkUrl] = useState<string | null>(null);

--- a/src/ui/components/TrackArtwork.tsx
+++ b/src/ui/components/TrackArtwork.tsx
@@ -33,18 +33,20 @@ interface TrackArtworkProps {
   loading?: "eager" | "lazy";
   retryOnError?: boolean;
   /**
-   * Skips the direct-URL ladder and goes straight to the Rust proxy.
+   * Starts the Rust proxy fetch immediately instead of waiting for the direct-URL ladder to be
+   * exhausted first — a race, not a replacement.
    *
-   * For a source that's effectively guaranteed to need it anyway — `googleusercontent` artist
-   * portraits refuse the webview's referer far more often than they accept it — walking every
-   * direct candidate first (each a real network round trip that has to fail before the next one
-   * even starts) turns a single avatar into the slowest thing on the page, and worse, into
-   * something that can still be mid-walk if the view unmounts before it finishes: the proxy
-   * fetch itself keeps running and caches its result regardless, so the *next* mount pays
-   * nothing, but this one shows the placeholder for however long the walk had left. One flag
-   * rather than fixing the ladder's speed: everything else on the ladder resolves directly far
-   * more often than not, and racing the proxy against it there would trade a rare slow cover for
-   * a proxy request on every fast one.
+   * For a source that needs the proxy more often than not — `googleusercontent` artist portraits
+   * refuse the webview's referer far more often than they accept it — waiting for every direct
+   * candidate to fail first (each a real network round trip) before even starting the proxy
+   * meant a mount could still be mid-walk when the view unmounted: the proxy fetch keeps running
+   * and caches its result regardless, so the *next* mount paid nothing, but this one sat on the
+   * placeholder for however long the walk had left.
+   *
+   * Deliberately still a race and not a straight swap to proxy-only: the direct ladder stays in
+   * play as a live fallback. A proxy-only first cut of this traded that away — one network hiccup
+   * on the single remaining path and there was nothing left to fall back to, which is a worse
+   * failure mode than the slow walk it replaced.
    */
   preferProxy?: boolean;
   /**
@@ -91,10 +93,10 @@ export function TrackArtwork({
     if (!artworkUrl?.trim()) return [];
     const cached = cacheKey ? getResolvedArtworkUrl(cacheKey) : undefined;
     if (cached) return [cached];
-    // Empty candidates is what already makes embedded artwork skip straight to the proxy
-    // effect below — preferProxy asks for the exact same shortcut for a remote URL.
-    return isLocalArtwork || preferProxy ? [] : getArtworkUrlCandidates(artworkUrl, sizeBucket);
-  }, [artworkUrl, cacheKey, isLocalArtwork, preferProxy, sizeBucket]);
+    // preferProxy does not touch this ladder — it stays a live fallback even while the proxy
+    // races it below. Only truly local artwork (no URL to walk at all) skips it.
+    return isLocalArtwork ? [] : getArtworkUrlCandidates(artworkUrl, sizeBucket);
+  }, [artworkUrl, cacheKey, isLocalArtwork, sizeBucket]);
   const [artworkIndex, setArtworkIndex] = useState(0);
   const [retryCount, setRetryCount] = useState(0);
   const [proxiedArtworkUrl, setProxiedArtworkUrl] = useState<string | null>(null);
@@ -156,9 +158,14 @@ export function TrackArtwork({
   }, [baseArtworkUrl]);
 
   useEffect(() => {
-    if (!artworkUrl || !cacheKey || artworkIndex < artworkCandidates.length || proxiedArtworkUrl) {
-      return;
-    }
+    if (!artworkUrl || !cacheKey || proxiedArtworkUrl) return;
+    /*
+     * Ordinarily waits for the direct ladder to be exhausted — starting a proxy fetch nothing
+     * may end up needing is wasted work for the common cover that resolves directly. preferProxy
+     * is the one opt-in exception: for a source expected to need it anyway, waiting out however
+     * many direct candidates are left is exactly the delay this flag exists to skip.
+     */
+    if (!preferProxy && artworkIndex < artworkCandidates.length) return;
     // Every candidate already failed for this source once; re-walking earns the same 404s.
     if (hasArtworkFailed(cacheKey)) {
       // The one branch in this component that used to leave nothing behind: a mount landing
@@ -210,7 +217,17 @@ export function TrackArtwork({
     return () => {
       active = false;
     };
-  }, [artworkCandidates.length, artworkIndex, artworkUrl, cacheKey, isLocalArtwork, isLocalImage, sizeBucket, proxiedArtworkUrl]);
+  }, [
+    artworkCandidates.length,
+    artworkIndex,
+    artworkUrl,
+    cacheKey,
+    isLocalArtwork,
+    isLocalImage,
+    preferProxy,
+    sizeBucket,
+    proxiedArtworkUrl,
+  ]);
 
   return (
     <span

--- a/src/ui/components/TrackArtwork.tsx
+++ b/src/ui/components/TrackArtwork.tsx
@@ -10,6 +10,7 @@ import {
   rememberResolvedArtworkUrl,
   resolveArtworkThroughProxy,
 } from "../../internal/artworkCache";
+import { logInternalDebug } from "../../internal/logging";
 import { tauriFetch } from "../../datasource/youtube/tauriFetch";
 import { LOCAL_ARTWORK_PREFIX, LOCAL_IMAGE_PREFIX } from "../../player/localPlaylists";
 
@@ -159,7 +160,14 @@ export function TrackArtwork({
       return;
     }
     // Every candidate already failed for this source once; re-walking earns the same 404s.
-    if (hasArtworkFailed(cacheKey)) return;
+    if (hasArtworkFailed(cacheKey)) {
+      // The one branch in this component that used to leave nothing behind: a mount landing
+      // inside another mount's failure window sat on the fallback icon for up to
+      // FAILURE_TTL_MS with no sign anywhere of why. Debug, not warn — the failure itself was
+      // already logged by whichever attempt actually made the request.
+      logInternalDebug("TrackArtwork withheld, source recently failed", { cacheKey, variant });
+      return;
+    }
 
     let active = true;
 

--- a/src/ui/pages/ArtistView.tsx
+++ b/src/ui/pages/ArtistView.tsx
@@ -88,9 +88,24 @@ export function ArtistView({
   const { openPlaylistPicker, openTrackMenu } = useTrackContextMenu();
   const { openPlaylistMenu, openAlbumMenu } = usePlaylistContextMenu();
   const { currentTrackId, isPlaying, isLoading: isPlayerLoading } = useNowPlaying();
-  const [page, setPage] = useState<ArtistPage | null>(null);
+  /*
+   * Seeded from the remembered page, not always null.
+   *
+   * `useEffect` runs after the first paint, so setting this from inside the effect (as the
+   * artist-change branch below still needs to, for switching artists without unmounting) left a
+   * remount's very first frame — the one right after switching tabs back — rendering with
+   * nothing, before the effect caught it up a moment later. Whether that flash was visible
+   * depended on timing against the browser's paint, which is exactly an intermittent "sometimes
+   * shows, sometimes doesn't". Seeding here means a remounted, already-viewed artist has the
+   * right data on the very first render, flash or race no longer possible.
+   */
+  const [page, setPage] = useState<ArtistPage | null>(
+    () => (artist ? artistPageMemory.get(artist.id) ?? null : null),
+  );
   const [showAllSongs, setShowAllSongs] = useState(false);
-  const [isLoading, setIsLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState(
+    () => !(artist && artistPageMemory.has(artist.id)),
+  );
   const [error, setError] = useState<string | null>(null);
   const [filter, setFilter] = useState<ReleaseFilter>("all");
   const [isSubscribing, setIsSubscribing] = useState(false);
@@ -298,6 +313,12 @@ export function ArtistView({
          * refetching the image through Tauri and painting the bytes, which is what rescues a
          * url the webview refuses to load directly — the hand-rolled <img> here had no such
          * step, and looped back to the first candidate forever once they had all failed.
+         *
+         * preferProxy: an artist portrait is a googleusercontent URL far more often than not,
+         * and those routinely refuse the webview's own referer — walking the direct ladder first
+         * meant this one avatar could still be mid-resolution when you switched away, so it took
+         * two visits to actually see it: one to kick the walk off, another after it had finished
+         * in the background regardless of whether this component was still around to see it.
          */
         artworkSlot={
           <TrackArtwork
@@ -307,6 +328,7 @@ export function ArtistView({
             iconSize={72}
             variant="artist"
             loading="eager"
+            preferProxy
           />
         }
         actionsDisabled={isLoading || Boolean(error) || !page?.allSongs.length}

--- a/src/ui/pages/ArtistView.tsx
+++ b/src/ui/pages/ArtistView.tsx
@@ -315,10 +315,10 @@ export function ArtistView({
          * step, and looped back to the first candidate forever once they had all failed.
          *
          * preferProxy: an artist portrait is a googleusercontent URL far more often than not,
-         * and those routinely refuse the webview's own referer — walking the direct ladder first
-         * meant this one avatar could still be mid-resolution when you switched away, so it took
-         * two visits to actually see it: one to kick the walk off, another after it had finished
-         * in the background regardless of whether this component was still around to see it.
+         * and those routinely refuse the webview's own referer. The direct ladder stays as a
+         * live fallback either way — this only starts the Rust proxy racing it immediately
+         * instead of waiting for the (likely) direct failures first, so switching away mid
+         * resolution no longer meant the avatar was still mid-walk whenever you came back.
          */
         artworkSlot={
           <TrackArtwork


### PR DESCRIPTION
Follow-up to #67, which only fixed part of the tab-switch remount race.

- Seed `page` synchronously (`useState` initializer, not `useEffect`) — the effect-based version still had a one-frame gap after remount, timing-dependent against paint.
- Throttle `getArtist`'s background refresh to once per 60s per artist — it was unconditionally refetching the whole page on every cache-hit call, so rapid tab-switching repeated it 3x in 13s.
- Log `TrackArtwork`'s silent `hasArtworkFailed` early-return, previously the one branch that left no trace in the logs.
- `preferProxy`: race the Rust proxy against the direct-URL ladder instead of replacing it — a proxy-only first cut removed the fallback entirely, causing occasional placeholder-on-initial-load.