### PR TITLE
Fix macOS release build: borrow-checker error in macos_media.rs

### DIFF
--- a/src-tauri/src/macos_media.rs
+++ b/src-tauri/src/macos_media.rs
@@ -136,7 +136,7 @@ fn spawn_artwork_fetch(app: &AppHandle, url: String) {
         };
         if let Ok(mut state) = session.0.lock() {
             state.fetch = Some((url, bytes));
-        }
+        };
     });
 }
 


### PR DESCRIPTION
The 1.3.2 release build is failing on both macOS targets with E0597 in `spawn_artwork_fetch` — the `if let` over `session.0.lock()` as the async block's last expression reads as `session` dropping before a temporary that borrows from it. rustc's own suggested fix: a semicolon after the `if let` so its temporaries drop immediately.

Only surfaces on macOS since `macos_media` is `#[cfg(target_os = "macos")]`-gated — nothing else compiles the file, so this couldn't be caught by typecheck or the Linux/Windows builds.