### PR TITLE
Output device picker + fix crossfade stall on minimize

### DIFF
--- a/src-tauri/src/audio.rs
+++ b/src-tauri/src/audio.rs
@@ -22,7 +22,7 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use rodio::stream::{DeviceSinkBuilder, MixerDeviceSink};
-use rodio::{Player, Source};
+use rodio::{DeviceTrait, Player, Source};
 use serde::Serialize;
 use symphonia::core::io::MediaSource;
 use tauri::{AppHandle, Emitter};
@@ -248,6 +248,13 @@ pub(crate) enum Command {
         muted: bool,
     },
     Rate(f32),
+    /// Reopens the stream on a different device, `None` for the OS default. Both decks are lost
+    /// with the old stream — the caller reloads whatever was playing, the same way a track
+    /// recovers from a dead connection elsewhere in this pipeline.
+    SetOutputDevice {
+        id: Option<String>,
+        reply: Sender<Result<(), String>>,
+    },
     Transition {
         track_id: String,
         fade_ms: u64,
@@ -273,11 +280,14 @@ pub(crate) enum Command {
 pub(crate) struct NativeAudio {
     sender: Mutex<Option<Sender<Command>>>,
     app: AppHandle,
+    /// Which device the next lazy thread start should open. Only consulted at startup — a
+    /// change after that goes through `Command::SetOutputDevice` instead, via `set_output_device`.
+    pending_device: Mutex<Option<String>>,
 }
 
 impl NativeAudio {
     pub(crate) fn new(app: AppHandle) -> Self {
-        Self { sender: Mutex::new(None), app }
+        Self { sender: Mutex::new(None), app, pending_device: Mutex::new(None) }
     }
 
     /**
@@ -297,9 +307,14 @@ impl NativeAudio {
             let (tx, rx) = mpsc::channel();
             let (ready_tx, ready_rx) = mpsc::channel();
             let app = self.app.clone();
+            let device = self
+                .pending_device
+                .lock()
+                .map_err(|_| "native audio lock poisoned".to_string())?
+                .clone();
             std::thread::Builder::new()
                 .name("zuno-audio".into())
-                .spawn(move || run(app, rx, ready_tx))
+                .spawn(move || run(app, rx, ready_tx, device))
                 .map_err(|error| format!("audio thread failed to start: {error}"))?;
 
             ready_rx
@@ -313,6 +328,109 @@ impl NativeAudio {
             .send(command)
             .map_err(|_| "audio thread is gone".to_string())
     }
+
+    /**
+     * Sets which output device the engine writes to, `None` for the OS default.
+     *
+     * Before the thread exists this only records the preference for the next lazy start — it
+     * does not claim a device handle early, the same laziness `send` documents above. Once the
+     * thread is running, `pending_device` is never looked at again, so a change from here on
+     * hot-swaps the live stream instead.
+     */
+    pub(crate) fn set_output_device(&self, id: Option<String>) -> Result<(), String> {
+        let sender = self
+            .sender
+            .lock()
+            .map_err(|_| "native audio lock poisoned".to_string())?
+            .clone();
+
+        let Some(sender) = sender else {
+            *self
+                .pending_device
+                .lock()
+                .map_err(|_| "native audio lock poisoned".to_string())? = id;
+            return Ok(());
+        };
+
+        let (tx, rx) = mpsc::channel();
+        sender
+            .send(Command::SetOutputDevice { id, reply: tx })
+            .map_err(|_| "audio thread is gone".to_string())?;
+        rx.recv().map_err(|_| "audio thread dropped the request".to_string())?
+    }
+}
+
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct AudioOutputDevice {
+    /// `DeviceId::to_string()` — opaque, and the only part of this that round-trips through
+    /// `open_device_sink`. A device's name is not guaranteed unique or stable across a
+    /// reconnect on every backend; its id is what cpal documents as surviving both.
+    id: String,
+    name: String,
+    is_default: bool,
+}
+
+/**
+ * Enumerates cpal output devices.
+ *
+ * Pure enumeration, not routed through the audio thread — it never opens a device, so an
+ * IFrame-only user never pays for one just to see the dropdown, and it works before the thread
+ * has ever started.
+ */
+pub(crate) fn list_output_devices() -> Result<Vec<AudioOutputDevice>, String> {
+    use rodio::cpal::traits::HostTrait;
+
+    let host = rodio::cpal::default_host();
+    let default_id = host.default_output_device().and_then(|device| device.id().ok());
+    let devices = host
+        .output_devices()
+        .map_err(|error| format!("failed to list audio output devices: {error}"))?;
+
+    Ok(devices
+        .filter_map(|device| {
+            let id = device.id().ok()?;
+            let name = device.description().ok()?.name().to_string();
+            let is_default = default_id.as_ref() == Some(&id);
+            Some(AudioOutputDevice { id: id.to_string(), name, is_default })
+        })
+        .collect())
+}
+
+/**
+ * Opens the sink for `id`, or the OS default when `id` is `None`.
+ *
+ * A device id that no longer resolves — unplugged, a saved choice from a machine that changed
+ * underneath it — falls back to the default rather than refusing outright. The alternative is a
+ * stored preference from weeks ago turning into silence the user has to notice and go fix in
+ * settings, which is a worse failure than picking a device for them.
+ */
+fn open_device_sink(id: Option<&str>) -> Result<MixerDeviceSink, String> {
+    let device = id.and_then(|id| {
+        let device = find_output_device(id);
+        if device.is_none() {
+            eprintln!(
+                "[internal][tauri][warn] native_audio output device not found, using default id={}",
+                id
+            );
+        }
+        device
+    });
+
+    match device {
+        Some(device) => DeviceSinkBuilder::from_device(device)
+            .and_then(DeviceSinkBuilder::open_stream)
+            .map_err(|error| format!("failed to open audio output device: {error}")),
+        None => DeviceSinkBuilder::open_default_sink()
+            .map_err(|error| format!("no audio output device: {error}")),
+    }
+}
+
+fn find_output_device(id: &str) -> Option<rodio::Device> {
+    use rodio::cpal::traits::HostTrait;
+
+    let id: rodio::cpal::DeviceId = id.parse().ok()?;
+    rodio::cpal::default_host().device_by_id(&id)
 }
 
 /// Sends a command and waits for its reply, mapping a dead thread to an error rather than a
@@ -328,11 +446,16 @@ pub(crate) fn request<T>(
         .map_err(|_| "audio thread dropped the request".to_string())
 }
 
-fn run(app: AppHandle, rx: Receiver<Command>, ready: Sender<Result<(), String>>) {
-    let stream = match DeviceSinkBuilder::open_default_sink() {
+fn run(
+    app: AppHandle,
+    rx: Receiver<Command>,
+    ready: Sender<Result<(), String>>,
+    initial_device: Option<String>,
+) {
+    let stream = match open_device_sink(initial_device.as_deref()) {
         Ok(stream) => stream,
         Err(error) => {
-            let _ = ready.send(Err(format!("no audio output device: {error}")));
+            let _ = ready.send(Err(error));
             return;
         }
     };
@@ -595,6 +718,39 @@ impl Engine {
                 self.decks[self.active].clear();
                 self.playing = false;
             }
+            Command::SetOutputDevice { id, reply } => match open_device_sink(id.as_deref()) {
+                Ok(stream) => {
+                    let decks = [
+                        Deck {
+                            sink: Player::connect_new(stream.mixer()),
+                            track_id: None,
+                            duration_sec: 0.0,
+                            health: None,
+                        },
+                        Deck {
+                            sink: Player::connect_new(stream.mixer()),
+                            track_id: None,
+                            duration_sec: 0.0,
+                            health: None,
+                        },
+                    ];
+                    for deck in &decks {
+                        deck.sink.pause();
+                    }
+                    // Both old decks go with the old stream, so a fade referencing them would
+                    // be stale — dropped rather than settled through `cancel_fade`, which would
+                    // write a volume to a deck this is about to discard anyway.
+                    self.fade = None;
+                    self._stream = stream;
+                    self.decks = decks;
+                    self.active = 0;
+                    self.playing = false;
+                    let _ = reply.send(Ok(()));
+                }
+                Err(error) => {
+                    let _ = reply.send(Err(error));
+                }
+            },
         }
         false
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3808,6 +3808,24 @@ fn native_audio_drop_active(
     state.send(audio::Command::DropActive).map_err(cache_error)
 }
 
+/// Devices cpal can currently see, for the output-device picker in Settings.
+#[tauri::command]
+fn native_audio_list_output_devices() -> Result<Vec<audio::AudioOutputDevice>, CommandError> {
+    audio::list_output_devices().map_err(cache_error)
+}
+
+/// Switches the device the Rust engine plays to, by the `id` `native_audio_list_output_devices`
+/// reported. `id: None` is the OS default. See `NativeAudio::set_output_device` for what this
+/// does before playback has started versus during it — the latter clears both decks, so the
+/// frontend reloads whatever was playing.
+#[tauri::command]
+fn native_audio_set_output_device(
+    state: tauri::State<'_, audio::NativeAudio>,
+    id: Option<String>,
+) -> Result<(), CommandError> {
+    state.set_output_device(id).map_err(cache_error)
+}
+
 #[tauri::command]
 async fn fetch_youtube_music_audio(video_id: String) -> Result<AudioPayload, CommandError> {
     let started_at = Instant::now();
@@ -4735,6 +4753,8 @@ pub fn run() {
             native_audio_drop_standby,
             native_audio_drop_active,
             native_audio_set_equalizer,
+            native_audio_list_output_devices,
+            native_audio_set_output_device,
             media_server_release,
             proxy_http_request,
             load_youtube_music_cookie,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -18,6 +18,7 @@ import { hydrateMediaSessionSettings } from "./ui/settings/mediaSession";
 import { hydrateAudioQualitySettings } from "./internal/audioQuality";
 import { hydrateAudioEngineMode } from "./ui/settings/audioEngine";
 import { hydrateEqualizer } from "./ui/settings/equalizer";
+import { hydrateOutputDevice } from "./ui/settings/audioOutputDevice";
 import { hydrateYouTubeAccountSettings } from "./ui/settings/youtubeAccount";
 import { notifyLocalPlaylistsChanged, syncLocalAudioWatcher } from "./player/localPlaylists";
 import { listen } from "@tauri-apps/api/event";
@@ -72,6 +73,8 @@ void Promise.all([
   hydrateAudioEngineMode(),
   // Rust starts flat every launch, so the stored curve has to be pushed back down.
   hydrateEqualizer(),
+  // Same reason: a fresh Rust process opens the OS default device until told otherwise.
+  hydrateOutputDevice(),
   hydrateYouTubeAccountSettings(),
   hydrateLastFmSettings(),
   hydrateDiscordSettings(),

--- a/src/player/AudioEngine.ts
+++ b/src/player/AudioEngine.ts
@@ -71,6 +71,20 @@ declare global {
  */
 const STANDBY_IDLE_TEARDOWN_MS = 60_000;
 
+/**
+ * Crossfade ramp granularity for the IFrame engine. Matches `FADE_STEP` in `audio.rs` — 50 steps
+ * a second is well below what the ear resolves as stepping.
+ *
+ * A `setInterval`, not `requestAnimationFrame`: rAF is tied to the compositor's paint loop and
+ * stops firing outright while the window is hidden or minimized, which used to leave a track
+ * that started crossfading right before a minimize stuck at whatever volume the ramp had
+ * reached — silence or near it — until focus returned. `setInterval` keeps running in the
+ * background (browsers clamp its rate there, they do not stop it), and each tick still computes
+ * progress from real elapsed time, so a throttled run of ticks still lands on the right volume
+ * for however much wall-clock time has actually passed.
+ */
+const FADE_STEP_MS = 20;
+
 let iframeApiPromise: Promise<void> | null = null;
 const audioEngines = new Set<AudioEngine>();
 let playbackClaimId = 0;
@@ -246,7 +260,7 @@ export class AudioEngine {
    * The crossfade ramp. Held so a stop mid-transition can cancel it — a ramp that kept running
    * would set volumes on a deck that had already been torn down.
    */
-  private fadeFrameId: number | null = null;
+  private fadeIntervalId: number | null = null;
   private muted = false;
   private playbackRate = 1;
   private onEnded: (() => void) | null = null;
@@ -847,13 +861,12 @@ export class AudioEngine {
         incoming.setVolume(Math.round(targetPercent * Math.sin((progress * Math.PI) / 2)));
 
         if (progress >= 1) {
-          this.fadeFrameId = null;
+          window.clearInterval(this.fadeIntervalId!);
+          this.fadeIntervalId = null;
           resolve();
-          return;
         }
-        this.fadeFrameId = window.requestAnimationFrame(step);
       };
-      this.fadeFrameId = window.requestAnimationFrame(step);
+      this.fadeIntervalId = window.setInterval(step, FADE_STEP_MS);
     });
   }
 
@@ -922,9 +935,9 @@ export class AudioEngine {
   }
 
   private cancelFade(): void {
-    if (this.fadeFrameId !== null) {
-      window.cancelAnimationFrame(this.fadeFrameId);
-      this.fadeFrameId = null;
+    if (this.fadeIntervalId !== null) {
+      window.clearInterval(this.fadeIntervalId);
+      this.fadeIntervalId = null;
     }
   }
 

--- a/src/player/rustAudio.ts
+++ b/src/player/rustAudio.ts
@@ -122,6 +122,22 @@ export function setRate(rate: number): Promise<void> {
   return invoke("native_audio_set_rate", { rate });
 }
 
+export type OutputDevice = { id: string; name: string; isDefault: boolean };
+
+/** Devices cpal can currently see. Cheap — does not open a device or touch the audio thread. */
+export function listOutputDevices(): Promise<OutputDevice[]> {
+  return invoke<OutputDevice[]>("native_audio_list_output_devices");
+}
+
+/**
+ * Switches the device the engine plays to, by the `id` `listOutputDevices` reported. `null` is
+ * the OS default. Clears whatever was loaded if the audio thread was already running — the
+ * caller reloads the current track the same way a dead stream recovers elsewhere in this file.
+ */
+export function setOutputDevice(id: string | null): Promise<void> {
+  return invoke("native_audio_set_output_device", { id });
+}
+
 export function transition(trackId: string, fadeMs: number): Promise<boolean> {
   return invoke<boolean>("native_audio_transition", { trackId, fadeMs });
 }

--- a/src/ui/pages/SettingsPage.tsx
+++ b/src/ui/pages/SettingsPage.tsx
@@ -168,6 +168,13 @@ import {
   type AudioEngineMode,
 } from "../settings/audioEngine";
 import {
+  listOutputDevices,
+  setOutputDevice,
+  SYSTEM_DEFAULT_DEVICE,
+  useOutputDevice,
+  type OutputDevice,
+} from "../settings/audioOutputDevice";
+import {
   captureKeyboardShortcut,
   formatKeyboardShortcut,
   KEYBOARD_SHORTCUT_ACTIONS,
@@ -335,6 +342,61 @@ function EqualizerSettings({ engineMode }: { engineMode: AudioEngineMode }) {
         boost is held back rather than clipped — lower the preamp to hear the difference instead.
       </p>
     </div>
+  );
+}
+
+/**
+ * Which sound card the Rust engine writes to.
+ *
+ * Only the Rust engine opens one itself — the IFrame and native paths play through the webview
+ * and follow whatever the OS default routes to, same as any other browser tab.
+ */
+function OutputDeviceSetting({ engineMode }: { engineMode: AudioEngineMode }) {
+  const selected = useOutputDevice();
+  const [devices, setDevices] = useState<OutputDevice[]>([]);
+  const available = engineMode === "rust";
+
+  useEffect(() => {
+    let cancelled = false;
+    listOutputDevices()
+      .then((found) => {
+        if (!cancelled) setDevices(found);
+      })
+      // The row still works with an empty list — it just offers nothing but "System default".
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <SettingRow
+      title="Output device"
+      description="Which sound card the Rust engine plays to."
+      disabled={!available}
+    >
+      {(labelId) => (
+        <Select
+          className="w-52"
+          value={selected ?? SYSTEM_DEFAULT_DEVICE}
+          onValueChange={(value) => {
+            setOutputDevice(value === SYSTEM_DEFAULT_DEVICE ? null : value);
+          }}
+        >
+          <SelectTrigger aria-labelledby={labelId}>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={SYSTEM_DEFAULT_DEVICE}>System default</SelectItem>
+            {devices.map((device) => (
+              <SelectItem key={device.id} value={device.id}>
+                {device.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      )}
+    </SettingRow>
   );
 }
 
@@ -2081,6 +2143,8 @@ export function SettingsPage({
             <p className="px-1 text-xs text-muted-foreground">
               Applies from the next track.
             </p>
+
+            <OutputDeviceSetting engineMode={audioEngineMode} />
 
             <EqualizerSettings engineMode={audioEngineMode} />
 

--- a/src/ui/settings/audioOutputDevice.ts
+++ b/src/ui/settings/audioOutputDevice.ts
@@ -1,0 +1,98 @@
+import { useSyncExternalStore } from "react";
+import {
+  hydrateLocalJsonSetting,
+  readLocalJsonSetting,
+  writeLocalJsonSetting,
+} from "../../internal/durableLocalSetting";
+import { logInternalWarn } from "../../internal/logging";
+import { playerController } from "../../player/playerStore";
+import {
+  listOutputDevices as invokeListOutputDevices,
+  setOutputDevice as pushOutputDevice,
+  type OutputDevice,
+} from "../../player/rustAudio";
+import { usesRustAudioEngine } from "./audioEngine";
+
+export type { OutputDevice };
+export const listOutputDevices = invokeListOutputDevices;
+
+/**
+ * Which cpal output device the Rust engine writes to, by id. `null` is the OS default — what
+ * `open_default_sink` grabs when nothing has ever been chosen.
+ *
+ * Only the Rust engine has a device to pick: the IFrame and native paths play through the
+ * webview and follow the OS default the same as any other browser tab.
+ */
+const STORAGE_KEY = "audio-output-device";
+const CHANGE_EVENT = "audio-output-device-change";
+
+/** The `Select` sentinel for "no id" — Radix rejects an empty-string item value. */
+export const SYSTEM_DEFAULT_DEVICE = "system-default";
+
+function isDeviceId(value: unknown): value is string | null {
+  return value === null || typeof value === "string";
+}
+
+function read(): string | null {
+  return readLocalJsonSetting<string | null>(STORAGE_KEY, isDeviceId);
+}
+
+/**
+ * Pushes the choice down to Rust and, if the engine had a track loaded, reloads it — reopening
+ * the stream drops both decks, the same loss `PlayerController.recoverFromPrematureEnd`
+ * recovers from when a connection dies mid-track, reused here since a device switch empties the
+ * decks the same way.
+ *
+ * ponytail: a paused track blips playing for an instant before pausing back down, rather than
+ * teaching this a load-that-does-not-play path just for the one case where nothing was audible
+ * anyway.
+ */
+async function push(id: string | null): Promise<void> {
+  const session = usesRustAudioEngine() ? playerController.getPlayerSession() : null;
+  try {
+    await pushOutputDevice(id);
+  } catch (error) {
+    logInternalWarn("Output device push failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return;
+  }
+
+  if (!session?.currentTrack || session.status === "idle") return;
+  const wasPlaying = session.status === "playing";
+  await playerController.playTrackById(session.currentTrack.id);
+  if (session.positionSec > 0) await playerController.seekTo(session.positionSec);
+  if (!wasPlaying) await playerController.pause();
+}
+
+function subscribe(callback: () => void) {
+  window.addEventListener(CHANGE_EVENT, callback);
+  window.addEventListener("storage", callback);
+  return () => {
+    window.removeEventListener(CHANGE_EVENT, callback);
+    window.removeEventListener("storage", callback);
+  };
+}
+
+export function getOutputDevice(): string | null {
+  return read();
+}
+
+export function setOutputDevice(id: string | null): void {
+  writeLocalJsonSetting(STORAGE_KEY, id);
+  void push(id);
+  window.dispatchEvent(new Event(CHANGE_EVENT));
+}
+
+export async function hydrateOutputDevice(): Promise<void> {
+  await hydrateLocalJsonSetting(STORAGE_KEY, isDeviceId);
+  // A fresh Rust process always opens the OS default until told otherwise, so the stored choice
+  // has to be pushed down once at startup — nothing is loaded this early, so `push` just forwards
+  // it.
+  void push(read());
+  window.dispatchEvent(new Event(CHANGE_EVENT));
+}
+
+export function useOutputDevice(): string | null {
+  return useSyncExternalStore(subscribe, read, () => null);
+}


### PR DESCRIPTION
Two fixes off #78:

- **Output device picker**: Settings > Playback, gated to the Rust engine. `native_audio_set_output_device` hot-swaps the stream if it's already running, or just records the pending choice if it hasn't started yet (no eager device claim for IFrame-only users). A saved device id that no longer resolves falls back to the OS default instead of going silent.
- **Crossfade stall on minimize**: the IFrame crossfade ramped volume via `requestAnimationFrame`, which stops firing while the window is hidden/minimized — a track that started crossfading right before a minimize got stuck at whatever volume the ramp had reached until focus returned. Swapped to `setInterval`, which keeps running (throttled) in the background.

Closes #78