### PR TITLE
Add hide/unhide for library playlists

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -18,6 +18,7 @@ import { hydrateMediaSessionSettings } from "./ui/settings/mediaSession";
 import { hydrateAudioQualitySettings } from "./internal/audioQuality";
 import { hydrateAudioEngineMode } from "./ui/settings/audioEngine";
 import { hydrateEqualizer } from "./ui/settings/equalizer";
+import { hydrateHiddenPlaylists } from "./ui/settings/hiddenPlaylists";
 import { hydrateYouTubeAccountSettings } from "./ui/settings/youtubeAccount";
 import { notifyLocalPlaylistsChanged, syncLocalAudioWatcher } from "./player/localPlaylists";
 import { listen } from "@tauri-apps/api/event";
@@ -72,6 +73,7 @@ void Promise.all([
   hydrateAudioEngineMode(),
   // Rust starts flat every launch, so the stored curve has to be pushed back down.
   hydrateEqualizer(),
+  hydrateHiddenPlaylists(),
   hydrateYouTubeAccountSettings(),
   hydrateLastFmSettings(),
   hydrateDiscordSettings(),

--- a/src/ui/components/PlaylistContextMenu.tsx
+++ b/src/ui/components/PlaylistContextMenu.tsx
@@ -9,13 +9,14 @@ import {
 } from "react";
 import { cn } from "@/lib/utils";
 import { Loader } from "@/components/motion/loader";
-import { BookmarkActiveIcon, BookmarkIcon, CheckIcon, CopyIcon, DownloadIcon, ImageIcon, PencilIcon, TrashIcon } from "@/ui/icons";
+import { BookmarkActiveIcon, BookmarkIcon, CheckIcon, CopyIcon, DownloadIcon, EyeClosedIcon, EyeIcon, ImageIcon, PencilIcon, TrashIcon } from "@/ui/icons";
 import type { Album, Playlist } from "../../datasource/types";
 import type { LibraryController } from "../../player/LibraryController";
 import { isLocalPlaylist, LOCAL_IMAGE_PREFIX, setLocalPlaylistArtwork } from "../../player/localPlaylists";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { forgetArtworkSource } from "../../internal/artworkCache";
 import { exportPlaylist } from "../../player/playlistTransfer";
+import { hidePlaylist, unhidePlaylist, useHiddenPlaylistIds } from "../settings/hiddenPlaylists";
 import {
   PlaylistContext,
   type PlaylistContextMenuValue,
@@ -149,6 +150,15 @@ export function PlaylistContextMenuProvider({
   const isSaved = album
     ? libraryController.isAlbumSaved(album.id) || Boolean(album.playlistId && libraryController.isAlbumSaved(album.playlistId))
     : false;
+
+  const hiddenPlaylistIds = useHiddenPlaylistIds();
+  const isHiddenPlaylist = Boolean(playlist && hiddenPlaylistIds.includes(playlist.id));
+  const toggleHiddenPlaylist = () => {
+    if (!playlist) return;
+    if (isHiddenPlaylist) unhidePlaylist(playlist.id);
+    else hidePlaylist(playlist.id);
+    setPosition(null);
+  };
 
   const isLocalPlaylistMenu = playlist ? isLocalPlaylist(playlist) : false;
   // Liked Songs is a system list: it has no name of its own and cannot be removed.
@@ -391,6 +401,17 @@ export function PlaylistContextMenuProvider({
             >
               <CopyIcon size={18} />
               <span>Copy playlist URL</span>
+            </button>
+          )}
+          {playlist && (
+            <button
+              type="button"
+              role="menuitem"
+              className="flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-sm text-foreground transition-colors hover:bg-card disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+              onClick={toggleHiddenPlaylist}
+            >
+              {isHiddenPlaylist ? <EyeIcon size={18} /> : <EyeClosedIcon size={18} />}
+              <span>{isHiddenPlaylist ? "Unhide from library" : "Hide from library"}</span>
             </button>
           )}
           {canEditPlaylist && (

--- a/src/ui/icons.tsx
+++ b/src/ui/icons.tsx
@@ -57,6 +57,8 @@ export { MusicNoteIcon as MusicNoteActiveIcon } from "@solar-icons/react/bold/mu
 export { PlaylistIcon } from "@solar-icons/react/linear/playlist";
 export { PlaylistIcon as PlaylistActiveIcon } from "@solar-icons/react/bold/playlist";
 export { PlaylistMinimalisticIcon as PlaylistAddIcon } from "@solar-icons/react/linear/playlist-minimalistic";
+export { EyeIcon } from "@solar-icons/react/linear/eye";
+export { EyeClosedIcon } from "@solar-icons/react/linear/eye-closed";
 export { VinylIcon as AlbumIcon } from "@solar-icons/react/linear/vinyl";
 export { VinylIcon as AlbumActiveIcon } from "@solar-icons/react/bold/vinyl";
 export { Microphone2Icon as LyricsIcon } from "@solar-icons/react/linear/microphone-2";

--- a/src/ui/pages/LibraryPage.tsx
+++ b/src/ui/pages/LibraryPage.tsx
@@ -10,7 +10,7 @@ import {
 } from "react";
 import { motion } from "motion/react";
 import { cn } from "@/lib/utils";
-import { CloseIcon, SearchIcon } from "@/ui/icons";
+import { CloseIcon, EyeClosedIcon, EyeIcon, SearchIcon } from "@/ui/icons";
 import {
   Select,
   SelectContent,
@@ -32,6 +32,7 @@ import { usePlaylistContextMenu } from "../components/PlaylistContextMenu";
 import { useNowPlaying } from "../hooks/useNowPlaying";
 import { useTrackSelection } from "../hooks/useTrackSelection";
 import { isLikedSongsId, likedSongsCover } from "../likedSongsArtwork";
+import { useHiddenPlaylistIds } from "../settings/hiddenPlaylists";
 
 type LibraryTab = "songs" | "albums" | "artists" | "playlists";
 
@@ -199,6 +200,21 @@ export function LibraryPage({
     );
   }, [activeSort, library?.playlists, localPlaylists, normalizedQuery]);
 
+  /*
+   * A display filter, not a second data source: `playlists` above stays the full sorted list,
+   * so a hidden playlist keeps its place in that order the moment "show hidden" reveals it
+   * again, rather than jumping to wherever it would fall in a filtered-then-reappended list.
+   */
+  const hiddenPlaylistIds = useHiddenPlaylistIds();
+  const hiddenPlaylistIdSet = useMemo(() => new Set(hiddenPlaylistIds), [hiddenPlaylistIds]);
+  const [showHiddenPlaylists, setShowHiddenPlaylists] = useState(false);
+  const visiblePlaylists = useMemo(
+    () => playlists.filter((item) => !hiddenPlaylistIdSet.has(item.id)),
+    [playlists, hiddenPlaylistIdSet],
+  );
+  const hiddenPlaylistCount = playlists.length - visiblePlaylists.length;
+  const displayedPlaylists = showHiddenPlaylists ? playlists : visiblePlaylists;
+
   const allArtists = useMemo(() => {
     const byId = new Map<string, Artist>();
     /*
@@ -293,7 +309,7 @@ export function LibraryPage({
     songs: songs.length,
     albums: albums.length,
     artists: artists.length,
-    playlists: playlists.length,
+    playlists: visiblePlaylists.length,
   };
 
   if (!library) {
@@ -500,21 +516,43 @@ export function LibraryPage({
         playlists.length === 0 ? (
           <EmptyState noun="playlists" query={query.trim()} onClearQuery={() => setQuery("")} />
         ) : (
-          <div className={GRID}>
-            {playlists.map((playlist) => (
-              <AlbumCard
-                key={playlist.id}
-                artworkUrl={
-                  isLikedSongsId(playlist.id, playlist.kind)
-                    ? likedSongsCover
-                    : playlist.artworkUrl
-                }
-                title={playlist.title}
-                subtitle={playlist.owner}
-                onClick={() => onOpenPlaylist(playlist)}
-                onContextMenu={(event) => openPlaylistMenu(event, playlist)}
-              />
-            ))}
+          <div className="flex flex-col gap-3">
+            {hiddenPlaylistCount > 0 && (
+              <button
+                type="button"
+                onClick={() => setShowHiddenPlaylists((current) => !current)}
+                className="flex w-fit items-center gap-1.5 rounded-full bg-card/70 px-3 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                {showHiddenPlaylists ? <EyeClosedIcon size={14} /> : <EyeIcon size={14} />}
+                {showHiddenPlaylists ? "Hide the hidden playlists" : `Show ${hiddenPlaylistCount} hidden`}
+              </button>
+            )}
+            {displayedPlaylists.length === 0 ? (
+              <p className="px-2 py-16 text-center text-sm text-muted-foreground">
+                All your playlists are hidden.
+              </p>
+            ) : (
+              <div className={GRID}>
+                {displayedPlaylists.map((playlist) => (
+                  <div
+                    key={playlist.id}
+                    className={hiddenPlaylistIdSet.has(playlist.id) ? "opacity-40" : undefined}
+                  >
+                    <AlbumCard
+                      artworkUrl={
+                        isLikedSongsId(playlist.id, playlist.kind)
+                          ? likedSongsCover
+                          : playlist.artworkUrl
+                      }
+                      title={playlist.title}
+                      subtitle={playlist.owner}
+                      onClick={() => onOpenPlaylist(playlist)}
+                      onContextMenu={(event) => openPlaylistMenu(event, playlist)}
+                    />
+                  </div>
+                ))}
+              </div>
+            )}
           </div>
         )
       )}

--- a/src/ui/settings/hiddenPlaylists.ts
+++ b/src/ui/settings/hiddenPlaylists.ts
@@ -1,0 +1,82 @@
+import { useSyncExternalStore } from "react";
+import {
+  hydrateLocalJsonSetting,
+  readLocalJsonSetting,
+  writeLocalJsonSetting,
+} from "../../internal/durableLocalSetting";
+
+/**
+ * Playlist ids hidden from the Library page's Playlists tab.
+ *
+ * A display filter only — the playlist itself is untouched on YouTube's side, so hiding one is
+ * always reversible and never touches the network. Local playlists and Liked Songs can be
+ * hidden the same way as any other; nothing here is specific to a playlist kind.
+ */
+const STORAGE_KEY = "library-hidden-playlists";
+const CHANGE_EVENT = "hidden-playlists-change";
+const EMPTY: string[] = [];
+
+function isIdList(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
+/*
+ * Cached for the same reason as the equaliser settings: `readLocalJsonSetting` parses fresh
+ * JSON on every call, and a new array reference on every render is what makes
+ * `useSyncExternalStore` believe the store changed and re-render forever.
+ */
+let cached: string[] | null = null;
+
+function readIds(): string[] {
+  if (cached === null) {
+    cached = readLocalJsonSetting<string[]>(STORAGE_KEY, isIdList) ?? EMPTY;
+  }
+  return cached;
+}
+
+function writeIds(ids: string[]): void {
+  cached = ids;
+  writeLocalJsonSetting(STORAGE_KEY, ids);
+  window.dispatchEvent(new Event(CHANGE_EVENT));
+}
+
+function subscribe(callback: () => void) {
+  window.addEventListener(CHANGE_EVENT, callback);
+  window.addEventListener("storage", callback);
+  return () => {
+    window.removeEventListener(CHANGE_EVENT, callback);
+    window.removeEventListener("storage", callback);
+  };
+}
+
+if (typeof window !== "undefined") {
+  window.addEventListener("storage", () => {
+    cached = null;
+  });
+}
+
+export function isPlaylistHidden(playlistId: string): boolean {
+  return readIds().includes(playlistId);
+}
+
+export function hidePlaylist(playlistId: string): void {
+  const current = readIds();
+  if (current.includes(playlistId)) return;
+  writeIds([...current, playlistId]);
+}
+
+export function unhidePlaylist(playlistId: string): void {
+  const current = readIds();
+  if (!current.includes(playlistId)) return;
+  writeIds(current.filter((id) => id !== playlistId));
+}
+
+export async function hydrateHiddenPlaylists(): Promise<void> {
+  await hydrateLocalJsonSetting(STORAGE_KEY, isIdList);
+  cached = null;
+  window.dispatchEvent(new Event(CHANGE_EVENT));
+}
+
+export function useHiddenPlaylistIds(): string[] {
+  return useSyncExternalStore(subscribe, readIds, () => EMPTY);
+}


### PR DESCRIPTION
Adds the hide half of "pinning and hide/show" from the roadmap comment on this issue — pin is a separate feature, not bundled here.

- `Hide from library` / `Unhide from library` in the playlist context menu — wherever it already opens (Library page, sidebar, Browse, Search, artist/playlist views).
- Persisted per-device (localStorage, same pattern as the equaliser settings), display-only — never touches the playlist on YouTube's side.
- Library page's Playlists tab filters hidden ones out by default, with a `Show N hidden` toggle that reveals them dimmed in their normal sort position so unhiding is a right-click away.

Closes #80