### PR TITLE
Stop the crossfade preload retry storm on a refused embed

### DIFF
--- a/src/player/AudioEngine.ts
+++ b/src/player/AudioEngine.ts
@@ -238,6 +238,17 @@ export class AudioEngine {
   private standbyVideoId: string | null = null;
   private standbyPromise: Promise<void> | null = null;
   private standbyIdleTimerId: number | null = null;
+  /**
+   * The video id the standby deck's IFrame most recently reported unplayable (see `onError`).
+   *
+   * Without this, the crossfade ticker calls `preloadNext` with the same id every ~250ms, and a
+   * video YouTube refuses to embed — error 150/101, the video owner disallows embedded players —
+   * fails identically every time. That was thirty-odd retries of the same doomed embed inside
+   * the crossfade window before the transition finally gave up and surfaced the error. The
+   * restriction is a property of the video, not a transient hiccup, so there is no cooldown here
+   * — it just stops being retried until something else asks to preload a different track.
+   */
+  private lastFailedStandbyVideoId: string | null = null;
   private audio: HTMLAudioElement | null = null;
   private audioObjectUrl: string | null = null;
   private currentVideoId: string | null = null;
@@ -714,6 +725,7 @@ export class AudioEngine {
     if (this.useNativeAudio || this.audio) return;
     if (!videoId || videoId === this.currentVideoId) return;
     if (this.standbyVideoId === videoId || this.standbyPromise) return;
+    if (this.lastFailedStandbyVideoId === videoId) return;
 
     this.standbyPromise = this.cueStandby(videoId)
       .catch((error: unknown) => {
@@ -1277,6 +1289,9 @@ export class AudioEngine {
                 videoId: this.standbyVideoId,
                 code: event.data,
               });
+              // Read before discardStandby() clears it — that is the only copy of which video
+              // this error was actually about.
+              this.lastFailedStandbyVideoId = this.standbyVideoId;
               this.discardStandby();
               return;
             }


### PR DESCRIPTION
Partial fix for #77 — the retry-storm cleanup only

`AudioEngine.preloadNext` only skipped a video if it was already cued or mid-attempt. A standby `onError` (e.g. code 150/101 — the video owner disallows embedded players) clears both, so the crossfade ticker called `preloadNext` with the same id again ~250ms later. Same embed, same restriction, same error: one video in a user's log hit this thirty times across 13 seconds before the crossfade deadline forced a real load and the error finally reached them.

The restriction is a property of the video, not a transient hiccup, so there's no retry worth protecting — this just remembers the id an `onError` last failed and skips it on the next preload call.

Ref #77