### PR TITLE
Enforce single instance

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5037,6 +5037,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3214becf9ef5783c0ae99a3bb25adf5353a7a16ebf53e74b909e29205735c6c"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
+]
+
+[[package]]
 name = "tauri-plugin-updater"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6899,6 +6915,7 @@ dependencies = [
  "tauri-plugin-localhost",
  "tauri-plugin-opener",
  "tauri-plugin-process",
+ "tauri-plugin-single-instance",
  "tauri-plugin-updater",
  "tokio",
  "url",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,6 +22,7 @@ tauri = { version = "2", features = ["macos-private-api", "tray-icon", "image-pn
 tauri-plugin-autostart = "2"
 tauri-plugin-opener = "2"
 tauri-plugin-localhost = "2"
+tauri-plugin-single-instance = "2"
 portpicker = "0.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4599,6 +4599,20 @@ pub fn run() {
     let mut context = tauri::generate_context!();
     #[allow(unused_mut)]
     let mut builder = tauri::Builder::default()
+        /*
+         * First among plugins, per the plugin's own docs — it is the one deciding whether this
+         * process gets to keep running at all, so everything else registering a window, a tray
+         * icon or a background task first would be work thrown away the instant a second launch
+         * turns out to be redundant.
+         *
+         * The callback runs in the *original* process when a second launch is attempted; a
+         * second launch's own `main` never reaches this builder at all, since the plugin exits
+         * it immediately. Reuses the tray's own "bring to front" — a second launch is exactly
+         * that, wherever it came from.
+         */
+        .plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
+            show_main_window(app);
+        }))
         .manage(CacheLock(Mutex::new(())))
         .manage(AppSettingsLock(Mutex::new(())))
         .manage(YoutubeCookieJar(Mutex::new(CookieJarState::default())))


### PR DESCRIPTION
Adds `tauri-plugin-single-instance`, registered first in the plugin chain (per its own docs — it decides whether this process keeps running at all, so it has to win the race against everything else).

A second launch attempt now runs its callback in the *original* process and calls the same `show_main_window` helper the tray's "Show Zuno" already uses (show + unminimize + focus) — so it behaves identically whether the window is on-screen or hidden to tray, and a second launch never gets its own independent process.

Closes #76