### PR TITLE
fix: shuffle entire playlist queue and loop toggle

### DIFF
--- a/src/player/PlayerController.ts
+++ b/src/player/PlayerController.ts
@@ -376,6 +376,7 @@ export class PlayerController {
     videoId: string,
     playbackQueue?: readonly Track[],
     autoplayWhenQueueEnds = false,
+    shufflePlaylist = false,
   ): Promise<boolean> {
     // Close out whatever was playing first: this is the funnel every track change goes
     // through, so it catches a natural end and a skip with the same one call.
@@ -397,14 +398,17 @@ export class PlayerController {
     const hadLoadedTrack = this.loadedTrackId !== null;
     this.loadedTrackId = null;
     this.pendingSeekTime = null;
-    this.setState({ status: "loading", error: null });
     try {
       if (playbackQueue?.length) {
         const startIndex = playbackQueue.findIndex((track) => track.id === videoId);
         this.queue.set([...playbackQueue], startIndex >= 0 ? startIndex : 0);
         this.autoplayEnabled = autoplayWhenQueueEnds;
         this.isPlaylistMode = !autoplayWhenQueueEnds && playbackQueue.length > 1;
+        if (shufflePlaylist && this.isPlaylistMode) {
+          this.queue.shuffleAll(this.queue.queuedManually);
+        }
       }
+      this.setState({ status: "loading", error: null });
 
       const queuedTrack = playbackQueue?.find((item) => item.id === videoId)
         ?? this.queue.all.find((item) => item.id === videoId);
@@ -611,14 +615,20 @@ export class PlayerController {
    * tracks keep their position, because someone who explicitly said "play this next" did not
    * ask for it to be moved. Turning shuffle off restores the collection's original order rather
    * than leaving the shuffled arrangement frozen in place.
+   *
+   * Enabling shuffles whenever no un-shuffle snapshot exists, even if the flag already read
+   * "on": a freshly loaded playlist behind a stale persisted flag used to skip the reorder
+   * here, so "Shuffle" picked a random start track and left the rest in playlist order.
    */
   setShuffleEnabled(enabled: boolean): void {
-    if (this.shuffleEnabled === enabled) return;
     this.shuffleEnabled = enabled;
 
     if (this.isPlaylistMode) {
-      if (enabled) this.queue.shuffleRemaining(this.queue.queuedManually);
-      else this.queue.restoreOriginalOrder(this.queue.queuedManually);
+      if (!enabled) {
+        this.queue.restoreOriginalOrder(this.queue.queuedManually);
+      } else if (!this.queue.canRestoreOriginalOrder) {
+        this.queue.shuffleRemaining(this.queue.queuedManually);
+      }
     }
 
     logInternalInfo("PlayerController.setShuffleEnabled", {
@@ -791,6 +801,13 @@ export class PlayerController {
     this.queue.shuffleRemaining(this.queue.queuedManually);
     this.emit();
     logInternalInfo("PlayerController.shuffleUpcomingQueue");
+  }
+
+  /** Shuffles the whole source playlist around the current track, played songs included. */
+  shuffleEntirePlaylist(): void {
+    this.queue.shuffleAll(this.queue.queuedManually);
+    this.emit();
+    logInternalInfo("PlayerController.shuffleEntirePlaylist");
   }
 
   clearUpcomingQueue(): void {
@@ -991,11 +1008,12 @@ export class PlayerController {
          * listener notices immediately and reads as shuffle being broken.
          */
         if (this.shuffleEnabled && this.isPlaylistMode) {
+          this.queue.shuffleForLoop();
+        } else {
           this.queue.select(0);
-          this.queue.shuffleRemaining(this.queue.queuedManually);
         }
 
-        const firstTrack = this.queue.select(0);
+        const firstTrack = this.queue.current;
         if (firstTrack) {
           logInternalInfo("PlayerController.handleTrackEnded looping queue", {
             trackCount: this.queue.all.length,

--- a/src/player/Queue.check.ts
+++ b/src/player/Queue.check.ts
@@ -67,4 +67,36 @@ equal(ids(cleared), "a,b", "clearUpcoming keeps history and the current track");
 equal(cleared.current?.id, "b", "clearUpcoming does not stop what is playing");
 equal(cleared.queuedManually, 0, "clearUpcoming empties the manual run");
 
+// shuffleAll mixes played history back into the upcoming tail — the fix for "shuffle does
+// nothing on the last track of a playlist". Current track stays put; manual entries stay put.
+const lastTrack = new Queue();
+lastTrack.set([track("a"), track("b"), track("c"), track("d"), track("e")], 4);
+equal(lastTrack.all.length - (lastTrack.currentIndex + 1), 0, "nothing is upcoming on the last track");
+lastTrack.shuffleAll(0);
+equal(lastTrack.all.length, 5, "shuffleAll keeps every track in the queue");
+equal(lastTrack.current?.id, "e", "shuffleAll pins the current track");
+equal(ids(lastTrack).split(",").sort().join(","), "a,b,c,d,e", "shuffleAll loses nothing");
+check(
+  Array.from({ length: 20 }, () => {
+    lastTrack.shuffleAll(0);
+    return ids(lastTrack);
+  }).some((order) => order !== "a,b,c,d,e"),
+  "shuffleAll actually reorders (identity every time would mean the pool is never touched)",
+);
+
+// Manual entries survive untouched and keep their count.
+const withManual = new Queue();
+withManual.set([track("a"), track("b"), track("c"), track("d"), track("e")], 2);
+withManual.add(track("m1"));
+withManual.shuffleAll(withManual.queuedManually);
+equal(ids(withManual).split(",")[0], "c", "current track moves to the front");
+equal(ids(withManual).split(",")[1], "m1", "manual entry stays right after the current track");
+equal(withManual.queuedManually, 1, "manual count survives shuffleAll");
+
+// restoreOriginalOrder undoes a whole-queue shuffle exactly.
+withManual.restoreOriginalOrder(withManual.queuedManually);
+equal(ids(withManual), "a,b,c,m1,d,e", "restoreOriginalOrder rebuilds the full pre-shuffle state");
+equal(withManual.currentIndex, 2, "restoreOriginalOrder puts the cursor back");
+equal(withManual.queuedManually, 1, "restoreOriginalOrder restores the manual count");
+
 console.log("Queue: ok");

--- a/src/player/Queue.ts
+++ b/src/player/Queue.ts
@@ -4,6 +4,12 @@ export class Queue {
   private items: Track[] = [];
   /** Pre-shuffle order of the automatic tail, so shuffle mode can be undone. */
   private originalUpcoming: Track[] | null = null;
+  /** Full pre-shuffle state, captured when the whole queue was shuffled rather than just the tail. */
+  private fullOriginalOrder: {
+    items: Track[];
+    index: number;
+    manualQueueLength: number;
+  } | null = null;
   private index = -1;
   private manualQueueLength = 0;
 
@@ -25,8 +31,15 @@ export class Queue {
     return this.manualQueueLength;
   }
 
+  /** True while an un-shuffle snapshot exists — the tail order differs from the source order. */
+  get canRestoreOriginalOrder(): boolean {
+    return this.originalUpcoming !== null || this.fullOriginalOrder !== null;
+  }
+
   set(tracks: Track[], startIndex = 0, manualQueueLength = 0) {
     this.items = tracks;
+    this.originalUpcoming = null;
+    this.fullOriginalOrder = null;
     this.index = tracks.length === 0
       ? -1
       : Math.min(Math.max(startIndex, 0), tracks.length - 1);
@@ -67,6 +80,7 @@ export class Queue {
       Math.max(0, index - this.index),
     );
     this.originalUpcoming = null;
+    this.fullOriginalOrder = null;
   }
 
   playNext(track: Track): void {
@@ -163,6 +177,7 @@ export class Queue {
     }
     this.manualQueueLength = 0;
     this.originalUpcoming = null;
+    this.fullOriginalOrder = null;
   }
 
   select(index: number): Track | null {
@@ -216,7 +231,63 @@ export class Queue {
     this.items = [...this.items.slice(0, manualQueueEnd), ...upcoming];
   }
 
+  /**
+   * Shuffles the entire queue from the current track: what is playing moves to the front,
+   * hand-picked entries stay right after it, and everything else — played history included —
+   * goes into one shuffled pool after it. This makes every playlist track upcoming exactly once,
+   * including when the current song was near the end.
+   */
+  shuffleAll(manualCount: number): void {
+    if (this.index < 0) return;
+    const current = this.items[this.index];
+    const manual = this.items.slice(this.index + 1, this.index + 1 + manualCount);
+    const pool = [
+      ...this.items.slice(0, this.index),
+      ...this.items.slice(this.index + 1 + manualCount),
+    ];
+    if (pool.length === 0) return;
+
+    if (this.fullOriginalOrder === null && this.originalUpcoming === null) {
+      this.fullOriginalOrder = {
+        items: [...this.items],
+        index: this.index,
+        manualQueueLength: this.manualQueueLength,
+      };
+    }
+
+    for (let i = pool.length - 1; i > 0; i -= 1) {
+      const swapIndex = Math.floor(Math.random() * (i + 1));
+      [pool[i], pool[swapIndex]] = [pool[swapIndex], pool[i]];
+    }
+
+    this.items = [current, ...manual, ...pool];
+    this.index = 0;
+  }
+
+  /** Starts a new repeat-all lap with every queue entry in a fresh random order. */
+  shuffleForLoop(): void {
+    if (this.items.length <= 1) {
+      this.index = this.items.length === 0 ? -1 : 0;
+      return;
+    }
+
+    for (let index = this.items.length - 1; index > 0; index -= 1) {
+      const swapIndex = Math.floor(Math.random() * (index + 1));
+      [this.items[index], this.items[swapIndex]] = [this.items[swapIndex], this.items[index]];
+    }
+    this.index = 0;
+    this.manualQueueLength = 0;
+  }
+
   restoreOriginalOrder(manualCount: number): void {
+    if (this.fullOriginalOrder) {
+      this.items = [...this.fullOriginalOrder.items];
+      this.index = this.fullOriginalOrder.index;
+      this.manualQueueLength = this.fullOriginalOrder.manualQueueLength;
+      this.originalUpcoming = null;
+      this.fullOriginalOrder = null;
+      return;
+    }
     if (!this.originalUpcoming) return;
     const manualQueueEnd = this.index + 1 + manualCount;
     this.items = [...this.items.slice(0, manualQueueEnd), ...this.originalUpcoming];

--- a/src/player/playerStore.ts
+++ b/src/player/playerStore.ts
@@ -83,6 +83,7 @@ type PlayerControllerMethod =
   | "playQueueTrackAt"
   | "moveQueueTrack"
   | "shuffleUpcomingQueue"
+  | "shuffleEntirePlaylist"
   | "clearUpcomingQueue"
   | "addTracksToQueue"
   | "setStopAfterQueueIndex"
@@ -97,10 +98,12 @@ class ActivePlayerController implements PlayerControllerActions {
     videoId: string,
     playbackQueue?: Parameters<PlayerController["playTrackById"]>[1],
     autoplayWhenQueueEnds?: Parameters<PlayerController["playTrackById"]>[2],
+    shufflePlaylist?: Parameters<PlayerController["playTrackById"]>[3],
   ) => (await tabManager.claimFocusedPlayer()).playTrackById(
     videoId,
     playbackQueue,
     autoplayWhenQueueEnds,
+    shufflePlaylist,
   );
   play = () => tabManager.getActivePlayer().play();
   pause = () => tabManager.getActivePlayer().pause();
@@ -161,6 +164,7 @@ class ActivePlayerController implements PlayerControllerActions {
     insertAfter: boolean,
   ) => tabManager.getActivePlayer().moveQueueTrack(sourceIndex, targetIndex, insertAfter);
   shuffleUpcomingQueue = () => tabManager.getActivePlayer().shuffleUpcomingQueue();
+  shuffleEntirePlaylist = () => tabManager.getActivePlayer().shuffleEntirePlaylist();
   clearUpcomingQueue = () => tabManager.getActivePlayer().clearUpcomingQueue();
   addTracksToQueue = (tracks: Parameters<PlayerController["addTracksToQueue"]>[0]) =>
     tabManager.getActivePlayer().addTracksToQueue(tracks);

--- a/src/player/shuffleFlag.check.ts
+++ b/src/player/shuffleFlag.check.ts
@@ -1,0 +1,114 @@
+/**
+ * Self-check for the stale-shuffle-flag fix. No test runner in this project, so:
+ *
+ *   npx esbuild src/player/shuffleFlag.check.ts --bundle --platform=node --format=esm
+ *     --outfile=check.mjs && node check.mjs
+ *
+ * `setShuffleEnabled(true)` used to early-return when the persisted flag already read "on",
+ * so the playlist header's Shuffle action picked a random start track but never reordered
+ * what followed — Up next stayed as the unshuffled remains of the playlist. The fix reorders
+ * whenever no un-shuffle snapshot exists, regardless of the flag's previous value.
+ */
+export {};
+
+/* Hand-rolled stubs rather than a framework: this file only needs somewhere for module-level
+   localStorage reads (playback settings) and Tauri IPC log writes to land. */
+const store = new Map<string, string>();
+Object.assign(globalThis, {
+  localStorage: {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => void store.set(key, value),
+    removeItem: (key: string) => void store.delete(key),
+  },
+  window: {
+    __TAURI_INTERNALS__: {
+      invoke: () => Promise.resolve(null),
+      transformCallback: () => 0,
+    },
+  },
+});
+
+import { PlayerController } from "./PlayerController";
+import type { Track } from "../datasource/types";
+
+function check(condition: boolean, message: string): void {
+  if (!condition) throw new Error(`FAILED: ${message}`);
+}
+
+function equal(actual: unknown, expected: unknown, message: string): void {
+  check(actual === expected, `${message}: expected ${String(expected)}, got ${String(actual)}`);
+}
+
+const track = (id: string): Track => ({ id, source: "youtube", title: id, artist: "a" }) as Track;
+const ids = (controller: PlayerController) =>
+  controller.getPlayerSession().queue.map((item) => item.id).join(",");
+const SOURCE = ["a", "b", "c", "d", "e", "f"];
+
+function make(shuffleEnabled: boolean, isPlaylistMode = true): PlayerController {
+  const controller = new PlayerController({} as never);
+  controller.restoreSession({
+    currentTrack: null,
+    history: [],
+    queue: SOURCE.map(track),
+    queueIndex: 2,
+    status: "idle",
+    positionSec: 0,
+    volume: 1,
+    muted: false,
+    autoplayEnabled: false,
+    playbackOrderMode: "in-order",
+    shuffleEnabled,
+    isPlaylistMode,
+  });
+  return controller;
+}
+
+const sortedIds = (order: string) => order.split(",").sort().join(",");
+
+// The bug: flag persisted "on" from a previous session, playlist freshly loaded in order.
+// playShuffled calls setShuffleEnabled(true) again — this must actually reorder the tail now.
+{
+  const controller = make(true);
+  const before = ids(controller);
+  equal(before.split(",")[2], "c", "current track starts at its queue index");
+  controller.setShuffleEnabled(true);
+
+  const after = ids(controller);
+  equal(sortedIds(after), sortedIds(before), "shuffling loses no tracks");
+  equal(after.split(",")[0] + after.split(",")[1], "ab", "history before the cursor stays put");
+  equal(after.split(",")[2], "c", "current track keeps its slot");
+  check(
+    Array.from({ length: 10 }, () => {
+      controller.setShuffleEnabled(false);
+      controller.setShuffleEnabled(true);
+      return ids(controller);
+    }).some((order) => order !== before),
+    "repeated enable cycles do reshuffle a fresh tail (the fixed path)",
+  );
+}
+
+// Enabling twice in a row must not reshuffle an already-shuffled tail.
+{
+  const controller = make(false);
+  controller.setShuffleEnabled(true);
+  const once = ids(controller);
+  controller.setShuffleEnabled(true);
+  equal(ids(controller), once, "a redundant enable does not reshuffle");
+}
+
+// Disabling restores the source order exactly.
+{
+  const controller = make(false);
+  controller.setShuffleEnabled(true);
+  controller.setShuffleEnabled(false);
+  equal(ids(controller), "a,b,c,d,e,f", "disable rebuilds the original order");
+}
+
+// Non-playlist queues stay untouched by the toggle, as before.
+{
+  const controller = make(true, false);
+  controller.setShuffleEnabled(true);
+  equal(ids(controller), "a,b,c,d,e,f", "single-track/radio mode ignores the shuffle toggle");
+}
+
+console.log("shuffleFlag: ok");

--- a/src/ui/components/MediaHeader.tsx
+++ b/src/ui/components/MediaHeader.tsx
@@ -1,7 +1,7 @@
 import { useEffect, type ReactNode } from "react";
 import { cn } from "@/lib/utils";
 import { Tooltip } from "@/components/motion/tooltip";
-import { CheckIcon, DownloadIcon, ListIcon, PauseActiveIcon, PlayActiveIcon, PlaylistAddIcon, RepeatActiveIcon, ShuffleActiveIcon } from "@/ui/icons";
+import { CheckIcon, DownloadIcon, ListIcon, PauseActiveIcon, PlayActiveIcon, PlaylistAddIcon, RepeatActiveIcon, RepeatOneActiveIcon, ShuffleActiveIcon } from "@/ui/icons";
 import { SpinnerSteps } from "@/components/motion/loader";
 import { TrackArtwork } from "./TrackArtwork";
 import { setAmbientArtwork } from "../stores/ambientArtworkStore";
@@ -95,10 +95,12 @@ interface MediaHeaderProps {
   };
   /** Play-from-the-top-on-repeat. Omit to hide the control. */
   loop?: {
-    /** Plays from the top with repeat-all on, so the collection restarts instead of ending. */
+    /** Starts this collection with repeat-all enabled. */
     onPlay: () => void;
-    /** Reflects repeat-all being active for this collection. */
-    isActive?: boolean;
+    /** Cycles repeat-all → repeat-one → off when this collection is already playing. */
+    onCycle?: () => void;
+    /** Current loop mode for the icon and accessible label. */
+    mode?: "in-order" | "repeat-all" | "repeat-one";
   };
   actionsDisabled?: boolean;
   /** Extra controls beside play/shuffle, e.g. Subscribe. */
@@ -143,7 +145,8 @@ export function MediaHeader({
   const isLoading = playback?.isLoading ?? false;
   const downloadBusy = download?.isBusy ?? false;
   const downloadCounts = download?.counts;
-  const isLooping = loop?.isActive ?? false;
+  const loopMode = loop?.mode ?? "in-order";
+  const isLooping = loopMode !== "in-order";
   /*
    * The wash is painted by Layout, which sits above the scroll container this header lives
    * in — it has to start behind the search bar, and anything drawn here would be clipped at
@@ -229,13 +232,13 @@ export function MediaHeader({
           ) : null}
 
           {loop ? (
-            <Tooltip content="Play from the top and start over when it ends">
+            <Tooltip content={loopMode === "repeat-one" ? "Loop current song" : loopMode === "repeat-all" ? "Loop the whole playlist" : "Loop the whole playlist"}>
               <button
                 type="button"
                 disabled={actionsDisabled}
-                onClick={loop.onPlay}
+                onClick={isLooping && loop.onCycle ? loop.onCycle : loop.onPlay}
                 aria-pressed={isLooping}
-                aria-label="Play in loop"
+                aria-label={loopMode === "repeat-one" ? "Loop current song" : loopMode === "repeat-all" ? "Loop queue" : "Play in loop"}
                 className={cn(
                   "flex items-center gap-2 rounded-full px-4 py-2.5 text-sm font-medium transition-colors",
                   "disabled:pointer-events-none disabled:opacity-50",
@@ -245,8 +248,12 @@ export function MediaHeader({
                     : "bg-card text-foreground hover:bg-muted",
                 )}
               >
-                <RepeatActiveIcon size={18} aria-hidden="true" />
-                Loop
+                {loopMode === "repeat-one" ? (
+                  <RepeatOneActiveIcon size={18} aria-hidden="true" />
+                ) : (
+                  <RepeatActiveIcon size={18} aria-hidden="true" />
+                )}
+                {loopMode === "repeat-one" ? "Loop one" : loopMode === "repeat-all" ? "Loop all" : "Loop"}
               </button>
             </Tooltip>
           ) : null}

--- a/src/ui/components/player/QueuePanel.tsx
+++ b/src/ui/components/player/QueuePanel.tsx
@@ -7,6 +7,7 @@ import {
   DiceIcon,
   PauseIcon,
   PlaylistAddIcon,
+  ShuffleActiveIcon,
   ShuffleIcon,
   TrashIcon,
 } from "@/ui/icons";
@@ -708,6 +709,16 @@ export function QueuePanel({ onClose }: QueuePanelProps) {
               >
                 <ShuffleIcon size={16} aria-hidden="true" />
                 <span className="sr-only">Shuffle what's next</span>
+              </button>
+            </Tooltip>
+            <Tooltip content="Shuffle the whole playlist">
+              <button
+                type="button"
+                className={ICON_BUTTON}
+                onClick={() => playerController.shuffleEntirePlaylist()}
+              >
+                <ShuffleActiveIcon size={16} aria-hidden="true" />
+                <span className="sr-only">Shuffle the whole playlist</span>
               </button>
             </Tooltip>
             <Tooltip content="Save the queue as a playlist">

--- a/src/ui/pages/AlbumView.tsx
+++ b/src/ui/pages/AlbumView.tsx
@@ -171,8 +171,9 @@ export function AlbumView({ album, playerController, libraryController }: AlbumV
   const playShuffled = async () => {
     const firstTrack = shuffleTracks(tracks)[0];
     if (!firstTrack) return;
-    const started = await playerController.playTrackById(firstTrack.id, tracks);
-    if (started) playerController.setShuffleEnabled(true);
+    const started = await playerController.playTrackById(firstTrack.id, tracks, false, true);
+    if (!started) return;
+    playerController.setShuffleEnabled(true);
   };
 
   const handleAlbumSearchKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
@@ -199,7 +200,10 @@ export function AlbumView({ album, playerController, libraryController }: AlbumV
         onShuffle={() => void playShuffled()}
         loop={{
           onPlay: playInLoop,
-          isActive: isCurrentCollection && playbackOrderMode === "repeat-all",
+          onCycle: () => playerController.setPlaybackOrderMode(
+            playbackOrderMode === "repeat-all" ? "repeat-one" : "in-order",
+          ),
+          mode: isCurrentCollection ? playbackOrderMode : "in-order",
         }}
         onAddToQueue={() => playerController.addTracksToQueue(tracks)}
         onAddToPlaylist={() => openPlaylistPicker(tracks[0], tracks)}

--- a/src/ui/pages/ArtistView.tsx
+++ b/src/ui/pages/ArtistView.tsx
@@ -223,8 +223,9 @@ export function ArtistView({
     const songs = page?.allSongs ?? [];
     const firstTrack = shuffleTracks(songs)[0];
     if (!firstTrack) return;
-    const started = await playerController.playTrackById(firstTrack.id, songs);
-    if (started) playerController.setShuffleEnabled(true);
+    const started = await playerController.playTrackById(firstTrack.id, songs, false, true);
+    if (!started) return;
+    playerController.setShuffleEnabled(true);
   };
 
   /**

--- a/src/ui/pages/PlaylistView.tsx
+++ b/src/ui/pages/PlaylistView.tsx
@@ -677,7 +677,7 @@ export function PlaylistView({ playlist, playerController, libraryController }: 
     const firstTrack = shuffleTracks(tracks)[0];
     if (!firstTrack) return;
 
-    const started = await playerController.playTrackById(firstTrack.id, tracks);
+    const started = await playerController.playTrackById(firstTrack.id, tracks, false, true);
     if (!started) return;
     playerController.setShuffleEnabled(true);
     markPlaylistPlayed(playlist.id);
@@ -767,7 +767,10 @@ export function PlaylistView({ playlist, playerController, libraryController }: 
           onShuffle={() => void playShuffled()}
           loop={{
             onPlay: () => void playInLoop(),
-            isActive: isCurrentCollection && playbackOrderMode === "repeat-all",
+            onCycle: () => playerController.setPlaybackOrderMode(
+              playbackOrderMode === "repeat-all" ? "repeat-one" : "in-order",
+            ),
+            mode: isCurrentCollection ? playbackOrderMode : "in-order",
           }}
           /*
            * Whole-collection actions page in the rest of the playlist first. Acting on the


### PR DESCRIPTION
## What and why

This PR fixes playlist-wide shuffle and clarifies loop controls. Previously, pressing shuffle while a playlist was already in progress only reordered the remaining tail. For example, in a 91-song playlist near the end, Up next could contain only 8 songs; tracks that had already played were not returned to the queue. Playlist Shuffle now rebuilds the queue from the complete current playlist, keeps the selected/current track playing, moves it to the front, and shuffles every other playlist track after it. The queue is prepared before the loading state is emitted, so the UI does not briefly show the old partial count before switching to the full count. The PR also fixes the collection header Loop button, which previously could be enabled but not toggled back off, and makes its three loop states explicit.

Closes #88
Closes #98

## How it was checked

- [x] `npm run verify` passes — 30 checks passed
- [x] `cargo test` not required — no `src-tauri/` files changed
- [x] Ran the app and tested playlist Shuffle while the current track was near the end
- [x] Ran the app and tested the Up next shuffle actions
- [x] Ran the app and tested the collection header loop cycle
- [x] Screenshots included below

## What changed

### 1. Shuffle the whole playlist — issue #88 and #98

The queue now supports two distinct actions:

- **Shuffle what's next**: only reorders tracks already after the current track.
- **Shuffle the whole playlist**: includes tracks that already played, moves the current track to the front, and creates a new shuffled order for every other playlist track.

For a 91-song playlist, the expected result is:

- 1 current track
- 90 tracks in Up next

This works even when the current track was originally near the end of the playlist.

### 2. Queue update without the temporary partial count

Previously, playlist Shuffle first loaded the playlist in its original order and only shuffled afterward. That caused a visible intermediate state such as:

```text
Up next: 50 songs
Up next: 90 songs
```

The shuffle is now applied while the queue is being prepared, before the loading state is emitted. The user sees the final queue directly.

### 3. Loop header toggle bug and Loop one state — issue #98

 The collection header previously allowed Loop to be enabled but not toggled back off. It now exposes the same three loop states already supported by the player controls:

```text
Loop      = off
Loop all  = repeat the whole playlist/queue
Loop one  = repeat the current song
```

Clicking cycles:

```text
Loop → Loop all → Loop one → Loop
```

The active state has a distinct label, tooltip, accessible name, and icon. `Loop one` uses the repeat-one icon with the `1` marker. The header can also be toggled back to off.

### 4. Shuffled repeat-all laps

When a shuffled playlist reaches its end with Loop all enabled, the next lap receives a fresh shuffled order instead of always restarting with the same queue item.

## Screenshots

### Issue #88 — Up next shuffle actions

The first screenshot shows **Shuffle what's next**. It preserves the current queue scope and only reorders the songs already ahead of the current track.

The second screenshot shows **Shuffle the whole playlist**. Its tooltip makes the broader action explicit. The queue contains 90 upcoming songs for the 91-song playlist, including tracks that had already played.

<img width="328" height="339" alt="shuffle-whats-next" src="https://github.com/user-attachments/assets/d11459dd-14d0-43b1-99be-ad9a8a1d1751" />

<img width="342" height="375" alt="shuffle-whole-playlist" src="https://github.com/user-attachments/assets/3570098a-3edd-46e6-a415-f9d49bebe930" />

###  issues #88 and #98 — Playlist-wide shuffle 

The playlist contains 91 songs, while the current track is selected from the collection. After using the playlist header Shuffle action, Up next shows 90 songs. The queue is rebuilt from the complete playlist, including tracks that had already played, instead of only shuffling the old remaining tail.

This implements the behavior requested in #88 and fixes the related queue behavior tracked in #98.

<img width="1614" height="332" alt="playlist-shuffle-result" src="https://github.com/user-attachments/assets/ad75b560-20ba-45bc-871b-f91725f70846" />

### Issue #98 — Loop toggle bug and new feature Loop one

The following screenshots show the header control states:

1. **Loop all** — highlighted control, tooltip `Loop the whole playlist`.
2. **Loop one** — highlighted control with the repeat-one icon, tooltip `Loop current song`.
3. **Loop off** — neutral control after toggling back off, tooltip `Loop the whole playlist`.

<img width="1614" height="332" alt="loop-all" src="https://github.com/user-attachments/assets/7339d9da-4016-4990-bc59-5c5222c73636" />

<img width="1614" height="332" alt="loop-one" src="https://github.com/user-attachments/assets/f741df2d-c467-483e-8d49-0ac08dc20002" />

<img width="1614" height="332" alt="loop-off" src="https://github.com/user-attachments/assets/695efc73-7ea4-456b-8665-f2c499419c2a" />

## Notes for the reviewer

- The existing **Shuffle what's next** behavior is intentionally preserved.
- Playlist/album/artist header Shuffle uses the full loaded collection and applies shuffle before the first player-state update.
- The queue keeps a snapshot so disabling shuffle can restore the original order.
-  The loop-state UI change is focused on the collection header and its state wiring.
- The player-bar three-state loop behavior remains compatible.
- Shuffled repeat-all laps now receive a fresh queue order instead of always restarting with the same first track.
- No Rust/Tauri backend code changed.
