### PR TITLE
fix: don't let TabManager reach zero tabs on close

### DIFF
--- a/src/player/TabManager.ts
+++ b/src/player/TabManager.ts
@@ -52,6 +52,15 @@ export class TabManager {
     return this.activeId;
   }
 
+  /**
+   * True when `id` is the last music tab left. Closing it would leave no player for
+   * `getActivePlayer()` to return — callers use this to keep at least one tab open, the way a
+   * browser refuses to close its last tab rather than closing the window.
+   */
+  isOnlyTab(id: MusicTabId): boolean {
+    return this.tabs.size === 1 && this.tabs.has(id);
+  }
+
   exportSession(): TabManagerSession {
     return {
       activeId: this.activeId,
@@ -65,6 +74,12 @@ export class TabManager {
   restoreSession(session: TabManagerSession): void {
     for (const [id, playerSession] of Object.entries(session.players)) {
       this.createTab(id).player.restoreSession(playerSession);
+    }
+
+    // A session saved while every music tab was closed (see `isOnlyTab`) has no players to
+    // restore; without this the app would relaunch straight into "No active music tab."
+    if (this.tabs.size === 0) {
+      this.createTab(session.activeId ?? "1");
     }
 
     if (session.activeId && this.tabs.has(session.activeId)) {
@@ -183,7 +198,9 @@ export class TabManager {
 
   removeTab(id: MusicTabId): void {
     const tab = this.tabs.get(id);
-    if (!tab) return;
+    // Backstop: every caller is expected to check `isOnlyTab` first, but if one doesn't, refusing
+    // here is what actually keeps `getActivePlayer()` from throwing "No active music tab."
+    if (!tab || this.isOnlyTab(id)) return;
 
     tab.player.dispose();
     this.tabs.delete(id);

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1259,6 +1259,10 @@ export default function App() {
   const handleCloseTab = (tabId: string) => {
     playerUIStore.setLyricsOpen(false);
     if (tabs.length === 1) return;
+    // Settings/Library/History/Browse tabs never get a tabManager entry, so `tabs.length` above
+    // can be >1 while this is still the last actual music tab — block that too, or TabManager
+    // is left with zero tabs and every playback control throws "No active music tab."
+    if (tabManager.isOnlyTab(tabId)) return;
 
     const closedTab = tabs.find((tab) => tab.id === tabId);
     if (!closedTab) return;
@@ -2002,6 +2006,7 @@ useEffect(() => {
             ? tabManager.getActivePlayerId()
             : null
         }
+        nonClosableTabId={tabs.find((tab) => tabManager.isOnlyTab(tab.id))?.id ?? null}
         sidebarWidth={sidebarWidth}
         isHomeActive={activeTab?.view === "home"}
         onNavigateHome={handleNavigateHome}

--- a/src/ui/components/ErrorBoundary.tsx
+++ b/src/ui/components/ErrorBoundary.tsx
@@ -66,7 +66,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
     return (
       <div
         role="alert"
-        className="flex h-full min-h-0 flex-col items-center justify-center gap-4 p-8 text-center"
+        className="flex h-full min-h-0 flex-col items-center justify-center gap-4 bg-background p-8 text-center"
       >
         <div className="flex flex-col gap-1.5">
           <h2 className="text-lg font-semibold text-foreground">{label} stopped working</h2>

--- a/src/ui/components/MusicTabs.tsx
+++ b/src/ui/components/MusicTabs.tsx
@@ -21,6 +21,8 @@ interface MusicTabsProps {
   tabs: Tab[];
   activeTabId: string;
   playingTabId: string | null;
+  /** The one music tab left with a player behind it — closing it would crash playback. */
+  nonClosableTabId?: string | null;
   onCreateTab: () => void;
   onCloseTab: (tabId: string) => void;
   onSwitchTab: (tabId: string) => void;
@@ -32,6 +34,7 @@ export function MusicTabs({
   tabs,
   activeTabId,
   playingTabId,
+  nonClosableTabId,
   onCreateTab,
   onCloseTab,
   onSwitchTab,
@@ -125,8 +128,6 @@ export function MusicTabs({
     };
   }, [onReorderTab]);
 
-  const canCloseTabs = tabs.length > 1;
-
   return (
     <div className="flex min-w-0 items-center overflow-hidden">
       <div
@@ -138,6 +139,7 @@ export function MusicTabs({
           const isActive = activeTabId === tab.id;
           const isDropBefore = dropTarget?.tabId === tab.id && !dropTarget.insertAfter;
           const isDropAfter = dropTarget?.tabId === tab.id && dropTarget.insertAfter;
+          const canCloseTab = tabs.length > 1 && tab.id !== nonClosableTabId;
 
           return (
             <div
@@ -217,7 +219,7 @@ export function MusicTabs({
                 </span>
               </div>
 
-              {canCloseTabs && (
+              {canCloseTab && (
                 <button
                   type="button"
                   className="-mr-1 shrink-0 rounded-full p-0.5 text-muted-foreground opacity-0 transition-opacity hover:text-foreground focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring group-hover:opacity-100"

--- a/src/ui/components/TitleBar.tsx
+++ b/src/ui/components/TitleBar.tsx
@@ -38,6 +38,7 @@ interface TitleBarProps {
   tabs: Tab[];
   activeTabId: string;
   playingTabId: string | null;
+  nonClosableTabId?: string | null;
   sidebarWidth: number;
   isHomeActive: boolean;
   onNavigateHome: () => void;
@@ -61,6 +62,7 @@ export function TitleBar({
   tabs,
   activeTabId,
   playingTabId,
+  nonClosableTabId,
   sidebarWidth,
   isHomeActive,
   onNavigateHome,
@@ -224,6 +226,7 @@ export function TitleBar({
         tabs={tabs}
         activeTabId={activeTabId}
         playingTabId={playingTabId}
+        nonClosableTabId={nonClosableTabId}
         onCreateTab={onCreateTab}
         onCloseTab={onCloseTab}
         onSwitchTab={onSwitchTab}


### PR DESCRIPTION
Closing the only music tab while a Settings/Library/History/Browse tab was open dropped `TabManager` to zero tabs — those views never get a `TabManager` entry, so `tabs.length` (used as the close guard) stayed >1 even though it was the last real tab. Every playback control then called `getActivePlayer()`, threw "No active music tab.", and tripped the Playback controls error boundary. Retry just remounted the same broken state, so it did nothing.

- `TabManager.removeTab` refuses to drop the last tab (backstop for any caller)
- `TabManager.restoreSession` heals a session persisted with 0 players
- `handleCloseTab` and the tab's close button check the real TabManager tab count instead of combined `tabs.length`
- `ErrorBoundary`'s fallback had no background — fixed the see-through render while in there