### PR TITLE
feat: equalizer bypass toggle, mini EQ in player bar, denormal fix

### DIFF
--- a/src-tauri/src/equalizer.rs
+++ b/src-tauri/src/equalizer.rs
@@ -32,6 +32,28 @@ const BAND_Q: f32 = 1.414_213_6;
 /// Gains beyond this are not tone control any more, and the preamp cannot buy back the headroom.
 const MAX_GAIN_DB: f32 = 12.0;
 
+/**
+ * Below this magnitude a sample is closer to silence than to signal — and closer to a
+ * denormal than either.
+ *
+ * A recursive filter fed quiet audio rings its history down toward zero exponentially, which
+ * means it eventually crosses into subnormal range and can sit there for a long stretch of a
+ * fade-out or a quiet intro. x86 FPUs drop to a microcode path for subnormals that can cost an
+ * order of magnitude more than a normal float op — on the real-time mixing thread, ten bands
+ * deep, that is a stall a listener can hear as a stutter. Flushing below this floor costs
+ * nothing audible and keeps every filter on the fast path.
+ */
+const DENORMAL_FLOOR: f32 = 1e-15;
+
+#[inline]
+fn flush_denormal(value: f32) -> f32 {
+    if value.abs() < DENORMAL_FLOOR {
+        0.0
+    } else {
+        value
+    }
+}
+
 #[derive(Clone, Copy, PartialEq)]
 pub(crate) struct EqualizerValues {
     pub(crate) preamp_db: f32,
@@ -152,8 +174,11 @@ impl Biquad {
         self.x2 = self.x1;
         self.x1 = input;
         self.y2 = self.y1;
-        self.y1 = output;
-        output
+        // The returned value feeds the next band's `input` in the cascade — flushing only the
+        // stored state and handing back the raw one would carry the denormal straight into the
+        // next filter's arithmetic instead of stopping it here.
+        self.y1 = flush_denormal(output);
+        self.y1
     }
 
     /// Swaps in new coefficients without disturbing the sample history, so a slider moved during
@@ -288,7 +313,31 @@ impl<S: Source> Source for EqualizedSource<S> {
 
 #[cfg(test)]
 mod tests {
-    use super::{Biquad, EqualizerValues, BAND_COUNT, BAND_HZ, MAX_GAIN_DB};
+    use super::{flush_denormal, Biquad, EqualizerValues, BAND_COUNT, BAND_HZ, MAX_GAIN_DB};
+
+    /// A value below the floor lands on exact zero; an audible one passes through untouched,
+    /// regardless of sign.
+    #[test]
+    fn denormals_are_flushed_to_exact_zero() {
+        assert_eq!(flush_denormal(1e-20), 0.0, "well below the floor must flush");
+        assert_eq!(flush_denormal(f32::MIN_POSITIVE / 2.0), 0.0, "an actual subnormal must flush");
+        assert_eq!(flush_denormal(-1e-20), 0.0, "flushing must not care about sign");
+        assert_eq!(flush_denormal(0.5), 0.5, "an audible value must pass through unchanged");
+        assert_eq!(flush_denormal(-0.5), -0.5);
+    }
+
+    /// A filter fed silence after a transient must ring its state down to exact zero rather
+    /// than lingering as a denormal — see `flush_denormal`.
+    #[test]
+    fn a_filter_settles_to_exact_zero_instead_of_ringing_forever() {
+        let mut filter = Biquad::peaking(1_000.0, 48_000.0, 12.0);
+        filter.process(1.0);
+        for _ in 0..10_000 {
+            filter.process(0.0);
+        }
+        assert_eq!(filter.y1, 0.0);
+        assert_eq!(filter.y2, 0.0);
+    }
 
     /// Runs a sine through a filter and returns its amplitude once the state has settled.
     fn response_at(mut filter: Biquad, frequency: f32, sample_rate: f32) -> f32 {

--- a/src/ui/components/player/MiniEqualizer.tsx
+++ b/src/ui/components/player/MiniEqualizer.tsx
@@ -1,0 +1,207 @@
+import { useCallback, useId, useRef, useState } from "react";
+import type { KeyboardEvent, PointerEvent } from "react";
+import { cn } from "@/lib/utils";
+import { Switch } from "@/components/motion/switch";
+import {
+  activeEqualizerPreset,
+  EQUALIZER_BANDS_HZ,
+  EQUALIZER_MAX_DB,
+  EQUALIZER_PRESETS,
+  isEqualizerFlat,
+  setEqualizer,
+  setEqualizerEnabled,
+  useEqualizer,
+  useEqualizerEnabled,
+} from "../../settings/equalizer";
+import { useAudioEngineMode } from "../../settings/audioEngine";
+
+/** Height of the bar well. Ten of these plus the preamp fit a 256px popup without scrolling. */
+const WELL_PX = 56;
+
+const clamp = (value: number, lo: number, hi: number) => Math.min(hi, Math.max(lo, value));
+
+/**
+ * One vertical bar: a bipolar gain control, filling up from centre for a boost and down for a
+ * cut. `RangeSlider` is horizontal only — built for a scale read left to right, not a bar read
+ * by height — so this is its own small control rather than a forced reuse of a component whose
+ * pointer maths run the wrong axis.
+ */
+function MiniEqBar({
+  label,
+  value,
+  disabled,
+  onChange,
+}: {
+  label: string;
+  value: number;
+  disabled: boolean;
+  onChange: (value: number) => void;
+}) {
+  const trackRef = useRef<HTMLDivElement>(null);
+  const [dragging, setDragging] = useState(false);
+
+  const commitFromY = useCallback(
+    (clientY: number) => {
+      const rect = trackRef.current?.getBoundingClientRect();
+      if (!rect) return;
+      // Centre of the well is 0 dB; distance from it, signed, scales to the full range.
+      const half = rect.height / 2;
+      const fromCentre = rect.top + half - clientY;
+      const gain = Math.round(clamp((fromCentre / half) * EQUALIZER_MAX_DB, -EQUALIZER_MAX_DB, EQUALIZER_MAX_DB));
+      onChange(gain);
+    },
+    [onChange],
+  );
+
+  const onPointerDown = (event: PointerEvent<HTMLDivElement>) => {
+    if (disabled) return;
+    event.currentTarget.setPointerCapture(event.pointerId);
+    setDragging(true);
+    commitFromY(event.clientY);
+  };
+
+  const onPointerMove = (event: PointerEvent<HTMLDivElement>) => {
+    if (!dragging || disabled) return;
+    commitFromY(event.clientY);
+  };
+
+  const endDrag = (event: PointerEvent<HTMLDivElement>) => {
+    event.currentTarget.releasePointerCapture?.(event.pointerId);
+    setDragging(false);
+  };
+
+  const onKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (disabled) return;
+    const map: Record<string, number> = {
+      ArrowUp: value + 1,
+      ArrowDown: value - 1,
+      Home: -EQUALIZER_MAX_DB,
+      End: EQUALIZER_MAX_DB,
+    };
+    if (event.key in map) {
+      event.preventDefault();
+      onChange(clamp(map[event.key], -EQUALIZER_MAX_DB, EQUALIZER_MAX_DB));
+    }
+  };
+
+  const ratio = value / EQUALIZER_MAX_DB;
+  const fillPx = Math.abs(ratio) * (WELL_PX / 2);
+  const fillTop = ratio >= 0 ? WELL_PX / 2 - fillPx : WELL_PX / 2;
+
+  return (
+    <div className="flex flex-col items-center gap-1">
+      <div
+        ref={trackRef}
+        role="slider"
+        tabIndex={disabled ? -1 : 0}
+        aria-label={`${label} gain`}
+        aria-orientation="vertical"
+        aria-valuemin={-EQUALIZER_MAX_DB}
+        aria-valuemax={EQUALIZER_MAX_DB}
+        aria-valuenow={value}
+        aria-disabled={disabled || undefined}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={endDrag}
+        onPointerCancel={endDrag}
+        onKeyDown={onKeyDown}
+        style={{ height: WELL_PX }}
+        className={cn(
+          "relative w-3 touch-none select-none rounded-full bg-muted outline-none",
+          "focus-visible:ring-2 focus-visible:ring-ring",
+          disabled ? "pointer-events-none opacity-50" : "cursor-grab active:cursor-grabbing",
+        )}
+      >
+        {/* Zero line — the reference every fill grows away from. */}
+        <div className="pointer-events-none absolute inset-x-0 top-1/2 h-px -translate-y-1/2 bg-foreground/25" />
+        <div
+          className="absolute inset-x-0 rounded-full bg-foreground/40 transition-[top,height] duration-100"
+          style={{ top: fillTop, height: fillPx }}
+        />
+        {/* The cap: what a finger or a screen reader's focus ring actually lands on. */}
+        <div
+          className="pointer-events-none absolute inset-x-0 h-1.5 rounded-full bg-foreground shadow-sm transition-[top] duration-100"
+          style={{ top: clamp(WELL_PX / 2 - (ratio * (WELL_PX / 2)) - 3, -3, WELL_PX - 3) }}
+        />
+      </div>
+      <span className="text-[9px] font-medium tabular-nums text-muted-foreground">{label}</span>
+    </div>
+  );
+}
+
+/**
+ * The equaliser, shrunk to fit the speed/sleep-timer popup.
+ *
+ * Vertical bars rather than the settings page's horizontal ones — a popup this narrow has width
+ * for a label or a slider but not both stacked ten times, and a bar you can read by height at a
+ * glance is what an equaliser looks like everywhere outside this app's own settings page.
+ */
+export function MiniEqualizer() {
+  const equalizer = useEqualizer();
+  const enabled = useEqualizerEnabled();
+  const available = useAudioEngineMode() === "rust";
+  const flat = isEqualizerFlat(equalizer);
+  const activePreset = activeEqualizerPreset(equalizer);
+  const labelId = useId();
+
+  const setBand = (index: number, gain: number) => {
+    const bandsDb = equalizer.bandsDb.slice();
+    bandsDb[index] = gain;
+    setEqualizer({ ...equalizer, bandsDb });
+  };
+
+  return (
+    <div className={cn("flex flex-col gap-2.5 border-t border-border pt-3", !available && "opacity-50")}>
+      <div className="flex items-center justify-between gap-2">
+        <span id={labelId} className="text-xs font-medium text-foreground">
+          Equaliser
+        </span>
+        <div className="flex items-center gap-2">
+          <span className="text-[11px] text-muted-foreground">
+            {available ? (enabled ? (flat ? "Flat" : "On") : "Off") : "Rust engine only"}
+          </span>
+          <Switch
+            checked={enabled}
+            onCheckedChange={setEqualizerEnabled}
+            disabled={!available}
+            aria-labelledby={labelId}
+          />
+        </div>
+      </div>
+
+      <div className={cn("flex flex-col gap-2", !enabled && "opacity-60")}>
+        <div className="flex flex-wrap gap-1">
+          {EQUALIZER_PRESETS.map((preset) => (
+            <button
+              key={preset.name}
+              type="button"
+              disabled={!available}
+              onClick={() => setEqualizer(preset.settings)}
+              className={cn(
+                "rounded-full px-2 py-0.5 text-[10px] font-medium transition-colors disabled:opacity-50",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
+                activePreset?.name === preset.name
+                  ? "bg-primary text-primary-foreground"
+                  : "bg-card text-foreground hover:bg-muted",
+              )}
+            >
+              {preset.name}
+            </button>
+          ))}
+        </div>
+
+        <div className="flex items-end justify-between gap-1 px-0.5">
+          {EQUALIZER_BANDS_HZ.map((hz, index) => (
+            <MiniEqBar
+              key={hz}
+              label={hz >= 1000 ? `${hz / 1000}k` : String(hz)}
+              value={equalizer.bandsDb[index]}
+              disabled={!available}
+              onChange={(gain) => setBand(index, gain)}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/components/player/PlaybackOptions.tsx
+++ b/src/ui/components/player/PlaybackOptions.tsx
@@ -4,6 +4,8 @@ import { Tooltip } from "@/components/motion/tooltip";
 import { ClockIcon, SpeedIcon } from "@/ui/icons";
 import { playerController } from "../../../player/playerStore";
 import { FloatingPanel } from "../FloatingPanel";
+import { MiniEqualizer } from "./MiniEqualizer";
+import { isEqualizerFlat, useEqualizer, useEqualizerEnabled } from "../../settings/equalizer";
 
 /** Offered speeds. Wider than a podcast app needs, narrow enough to stay a single row. */
 const SPEEDS = [0.75, 1, 1.25, 1.5, 2] as const;
@@ -15,11 +17,12 @@ const SLEEP_MINUTES = [15, 30, 45, 60, 90] as const;
 const formatCountdown = (remainingMs: number) => formatMinutesSeconds(Math.ceil(remainingMs / 1000));
 
 /**
- * Playback speed and sleep timer, behind one control.
+ * Playback speed, sleep timer and a mini equaliser, behind one control.
  *
- * They share a panel because they are the two "how this plays" settings that belong next to
- * the transport rather than buried in Settings — a sleep timer you cannot see counting down
- * is a sleep timer you do not trust.
+ * They share a panel because they are the "how this plays" settings that belong next to the
+ * transport rather than buried in Settings — a sleep timer you cannot see counting down is a
+ * sleep timer you do not trust, and an equaliser you have to leave the song for to adjust gets
+ * adjusted a lot less often than one sitting where you already are.
  */
 export function PlaybackOptions() {
   const [isOpen, setIsOpen] = useState(false);
@@ -29,6 +32,9 @@ export function PlaybackOptions() {
   );
 
   const isSleeping = remainingMs !== null;
+  const equalizer = useEqualizer();
+  const equalizerEnabled = useEqualizerEnabled();
+  const equalizerActive = equalizerEnabled && !isEqualizerFlat(equalizer);
 
   /*
    * Polled once a second rather than driven by player state: the deadline is wall-clock, so
@@ -65,7 +71,7 @@ export function PlaybackOptions() {
       triggerClassName="shrink-0"
       className="w-64"
       trigger={
-        <Tooltip content="Speed and sleep timer">
+        <Tooltip content="Speed, sleep timer and equaliser">
           <button
             type="button"
             onClick={() => setIsOpen((open) => !open)}
@@ -75,7 +81,7 @@ export function PlaybackOptions() {
             className={cn(
               "flex h-8 items-center justify-center gap-1 rounded-full px-2 text-muted-foreground transition-colors",
               "hover:bg-card hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-              (isSleeping || rate !== 1) && "text-primary",
+              (isSleeping || rate !== 1 || equalizerActive) && "text-primary",
             )}
           >
             {isSleeping ? (
@@ -151,6 +157,8 @@ export function PlaybackOptions() {
             Fades out over the last 20 seconds.
           </span>
         </div>
+
+        <MiniEqualizer />
       </div>
     </FloatingPanel>
   );

--- a/src/ui/pages/SettingsPage.tsx
+++ b/src/ui/pages/SettingsPage.tsx
@@ -10,12 +10,15 @@ import { Switch } from "@/components/motion/switch";
 import { Tabs, TabsList, TabsTrigger } from "@/components/motion/tabs";
 import { RangeSlider } from "@/components/motion/range-slider";
 import {
+  activeEqualizerPreset,
   EQUALIZER_BANDS_HZ,
   EQUALIZER_MAX_DB,
   EQUALIZER_PRESETS,
   isEqualizerFlat,
   setEqualizer,
+  setEqualizerEnabled,
   useEqualizer,
+  useEqualizerEnabled,
 } from "../settings/equalizer";
 import {
   MAX_CROSSFADE_SEC,
@@ -266,13 +269,18 @@ const SETTINGS_FIELD =
  * Sliders are horizontal, stacked. The usual picture of an equaliser is vertical, but that would
  * mean a second slider component built to be rotated, and the frequency and the gain read more
  * clearly written out than inferred from a bar's height.
+ *
+ * The switch is a bypass, not a reset — it never touches the stored curve, only whether Rust is
+ * currently told to apply it. See `setEqualizerEnabled`.
  */
 function EqualizerSettings({ engineMode }: { engineMode: AudioEngineMode }) {
   const equalizer = useEqualizer();
+  const enabled = useEqualizerEnabled();
   // Only the Rust engine has the samples. A track that fell back to the YouTube player plays
   // unequalised no matter what these say, which the note below is there to admit.
   const available = engineMode === "rust";
   const flat = isEqualizerFlat(equalizer);
+  const labelId = useId();
 
   const setBand = (index: number, gain: number) => {
     const bandsDb = equalizer.bandsDb.slice();
@@ -280,62 +288,78 @@ function EqualizerSettings({ engineMode }: { engineMode: AudioEngineMode }) {
     setEqualizer({ ...equalizer, bandsDb });
   };
 
-  const activePreset = EQUALIZER_PRESETS.find(
-    (preset) =>
-      preset.settings.preampDb === equalizer.preampDb
-      && preset.settings.bandsDb.every((gain, index) => gain === equalizer.bandsDb[index]),
-  );
+  const activePreset = activeEqualizerPreset(equalizer);
 
   return (
     <div className={cn("flex flex-col gap-3 pt-1", !available && "opacity-50")}>
-      <div className="flex items-baseline justify-between gap-4">
-        <span className="text-sm font-medium text-foreground">Equaliser</span>
-        <span className="text-xs text-muted-foreground">
-          {available
-            ? flat
-              ? "Off"
-              : `${equalizer.preampDb > 0 ? "+" : ""}${equalizer.preampDb} dB preamp`
-            : "Needs the Rust playback method"}
-        </span>
+      <div className="flex items-center justify-between gap-4">
+        <div className="flex flex-col gap-0.5">
+          <span id={labelId} className="text-sm font-medium text-foreground">
+            Equaliser
+          </span>
+          <span className="text-xs text-muted-foreground">
+            {available
+              ? enabled
+                ? flat
+                  ? "Flat"
+                  : `${equalizer.preampDb > 0 ? "+" : ""}${equalizer.preampDb} dB preamp`
+                : "Off"
+              : "Needs the Rust playback method"}
+          </span>
+        </div>
+        <Switch
+          checked={enabled}
+          onCheckedChange={setEqualizerEnabled}
+          disabled={!available}
+          aria-labelledby={labelId}
+        />
       </div>
 
-      <div className="flex flex-wrap gap-2">
-        {EQUALIZER_PRESETS.map((preset) => (
-          <button
-            key={preset.name}
-            type="button"
+      {/*
+        * Dimmed, not disabled: the curve is still worth shaping while off, the same way a
+        * hardware EQ's sliders keep moving with the bypass switch flipped — it is what makes
+        * flipping it back on show the shape you already built instead of the flat one it was
+        * silently holding underneath.
+        */}
+      <div className={cn("flex flex-col gap-3", !enabled && "opacity-60")}>
+        <div className="flex flex-wrap gap-2">
+          {EQUALIZER_PRESETS.map((preset) => (
+            <button
+              key={preset.name}
+              type="button"
+              disabled={!available}
+              onClick={() => setEqualizer(preset.settings)}
+              className={cn(
+                "rounded-full px-3 py-1 text-xs font-medium transition-colors disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
+                activePreset?.name === preset.name
+                  ? "bg-primary text-primary-foreground"
+                  : "text-foreground hover:bg-card",
+              )}
+            >
+              {preset.name}
+            </button>
+          ))}
+        </div>
+
+        <EqualizerBand
+          label="Preamp"
+          value={equalizer.preampDb}
+          disabled={!available}
+          onChange={(preampDb) => setEqualizer({ ...equalizer, preampDb })}
+        />
+
+        <div className="h-px bg-border" />
+
+        {EQUALIZER_BANDS_HZ.map((hz, index) => (
+          <EqualizerBand
+            key={hz}
+            label={hz >= 1000 ? `${hz / 1000}k` : String(hz)}
+            value={equalizer.bandsDb[index]}
             disabled={!available}
-            onClick={() => setEqualizer(preset.settings)}
-            className={cn(
-              "rounded-full px-3 py-1 text-xs font-medium transition-colors disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
-              activePreset?.name === preset.name
-                ? "bg-primary text-primary-foreground"
-                : "text-foreground hover:bg-card",
-            )}
-          >
-            {preset.name}
-          </button>
+            onChange={(gain) => setBand(index, gain)}
+          />
         ))}
       </div>
-
-      <EqualizerBand
-        label="Preamp"
-        value={equalizer.preampDb}
-        disabled={!available}
-        onChange={(preampDb) => setEqualizer({ ...equalizer, preampDb })}
-      />
-
-      <div className="h-px bg-border" />
-
-      {EQUALIZER_BANDS_HZ.map((hz, index) => (
-        <EqualizerBand
-          key={hz}
-          label={hz >= 1000 ? `${hz / 1000}k` : String(hz)}
-          value={equalizer.bandsDb[index]}
-          disabled={!available}
-          onChange={(gain) => setBand(index, gain)}
-        />
-      ))}
 
       <p className="px-1 text-xs text-muted-foreground">
         Applies immediately, to the track playing. A limiter sits after the bands, so a heavy

--- a/src/ui/settings/equalizer.ts
+++ b/src/ui/settings/equalizer.ts
@@ -1,8 +1,11 @@
 import { useSyncExternalStore } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import {
+  hydrateLocalBooleanSetting,
   hydrateLocalJsonSetting,
+  readLocalBooleanSetting,
   readLocalJsonSetting,
+  writeLocalBooleanSetting,
   writeLocalJsonSetting,
 } from "../../internal/durableLocalSetting";
 import { logInternalWarn } from "../../internal/logging";
@@ -57,8 +60,35 @@ export const EQUALIZER_PRESETS: ReadonlyArray<{ name: string; settings: Equalize
   },
 ];
 
+/**
+ * Which preset, if any, matches the current curve exactly.
+ *
+ * Shared by the full settings page and the player-bar mini equaliser so "which chip is lit"
+ * cannot drift into two slightly different definitions of "matches."
+ */
+export function activeEqualizerPreset(
+  settings: EqualizerSettings,
+): (typeof EQUALIZER_PRESETS)[number] | undefined {
+  return EQUALIZER_PRESETS.find(
+    (preset) =>
+      preset.settings.preampDb === settings.preampDb
+      && preset.settings.bandsDb.every((gain, index) => gain === settings.bandsDb[index]),
+  );
+}
+
 const STORAGE_KEY = "equalizer-v1";
 const CHANGE_EVENT = "equalizer-change";
+
+/*
+ * On/off, kept separate from the curve itself.
+ *
+ * The curve is what the sliders shape; the switch is whether it is currently being listened to.
+ * Folding it into `EqualizerSettings` would mean flattening the bands to turn it off and
+ * remembering them somewhere to turn it back on — this way the sliders keep the user's shape the
+ * whole time, on or off, exactly like a hardware EQ's bypass switch.
+ */
+const ENABLED_STORAGE_KEY = "equalizer-enabled-v1";
+const ENABLED_CHANGE_EVENT = "equalizer-enabled-change";
 
 function isEqualizerSettings(value: unknown): value is EqualizerSettings {
   if (typeof value !== "object" || value === null) return false;
@@ -74,6 +104,7 @@ function isEqualizerSettings(value: unknown): value is EqualizerSettings {
  * handed to `useSyncExternalStore` has to be reference-stable or React re-renders forever.
  */
 let cached: EqualizerSettings | null = null;
+let enabledCached: boolean | null = null;
 
 function readSettings(): EqualizerSettings {
   if (cached === null) {
@@ -92,10 +123,29 @@ export function isEqualizerAvailable(): boolean {
   return usesRustAudioEngine();
 }
 
+/** The bypass switch — independent of the curve. See `ENABLED_STORAGE_KEY`. */
+export function isEqualizerEnabled(): boolean {
+  if (enabledCached === null) {
+    enabledCached = readLocalBooleanSetting(ENABLED_STORAGE_KEY, true);
+  }
+  return enabledCached;
+}
+
+export function setEqualizerEnabled(enabled: boolean): void {
+  enabledCached = enabled;
+  writeLocalBooleanSetting(ENABLED_STORAGE_KEY, enabled, ENABLED_CHANGE_EVENT);
+  // Re-push under the new switch state — flat if this just turned it off, the stored curve if
+  // it just turned back on.
+  push(readSettings());
+}
+
+/// Rust has no notion of "off": it only ever sees a curve, flat or not. The switch lives here,
+/// entirely on the frontend, by choosing what to push rather than sending the switch itself.
 function push(settings: EqualizerSettings): void {
+  const applied = isEqualizerEnabled() ? settings : EQUALIZER_FLAT;
   void invoke("native_audio_set_equalizer", {
-    preampDb: settings.preampDb,
-    bandsDb: settings.bandsDb,
+    preampDb: applied.preampDb,
+    bandsDb: applied.bandsDb,
   }).catch((error: unknown) => {
     logInternalWarn("Equalizer push failed", {
       error: error instanceof Error ? error.message : String(error),
@@ -133,15 +183,27 @@ function subscribe(callback: () => void) {
   };
 }
 
+function subscribeEnabled(callback: () => void) {
+  window.addEventListener(ENABLED_CHANGE_EVENT, callback);
+  window.addEventListener("storage", callback);
+  return () => {
+    window.removeEventListener(ENABLED_CHANGE_EVENT, callback);
+    window.removeEventListener("storage", callback);
+  };
+}
+
 if (typeof window !== "undefined") {
   window.addEventListener("storage", () => {
     cached = null;
+    enabledCached = null;
   });
 }
 
 export async function hydrateEqualizer(): Promise<void> {
   await hydrateLocalJsonSetting(STORAGE_KEY, isEqualizerSettings);
+  await hydrateLocalBooleanSetting(ENABLED_STORAGE_KEY, true, ENABLED_CHANGE_EVENT);
   cached = null;
+  enabledCached = null;
   /*
    * Rust starts flat every launch — the values are process state, not a file — so the stored
    * settings have to be pushed down or the equaliser silently does nothing until the user
@@ -153,4 +215,8 @@ export async function hydrateEqualizer(): Promise<void> {
 
 export function useEqualizer(): EqualizerSettings {
   return useSyncExternalStore(subscribe, readSettings, () => EQUALIZER_FLAT);
+}
+
+export function useEqualizerEnabled(): boolean {
+  return useSyncExternalStore(subscribeEnabled, isEqualizerEnabled, () => true);
 }


### PR DESCRIPTION

- Denormal-flush fix in `Biquad::process()` (real-time stall risk during quiet passages)
- Enable/disable switch for the equaliser, independent of the stored curve
- Mini equaliser (vertical bars, presets, toggle) added to the player bar's speed/sleep-timer popup
- Shared `activeEqualizerPreset()` between settings and the mini view
