### PR TITLE
feat: content-shaped loading skeletons for home, album, artist, playlist

### DIFF
--- a/src/ui/components/Skeleton.tsx
+++ b/src/ui/components/Skeleton.tsx
@@ -1,0 +1,139 @@
+import type { CSSProperties } from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Shimmer placeholders shaped like the rows and cards they stand in for.
+ *
+ * A spinner says "wait"; a shape says "this is what's coming" — the difference between a web
+ * page and something that feels native. Every skeleton here is sized off the real component it
+ * precedes (`TrackRow`, `AlbumCard`, `PickCard`) so the swap from placeholder to content never
+ * jumps the layout.
+ *
+ * `aria-hidden` throughout: the loading state is announced once, by the `role="status"` wrapper
+ * around the whole group, not once per bar.
+ */
+
+/** The one shape every skeleton here is built from. */
+function SkeletonBlock({
+  className,
+  style,
+  delayMs = 0,
+}: {
+  className?: string;
+  style?: CSSProperties;
+  delayMs?: number;
+}) {
+  return (
+    <div
+      aria-hidden="true"
+      className={cn("animate-pulse rounded-lg bg-foreground/10", className)}
+      style={{ ...style, animationDelay: `${delayMs}ms` }}
+    />
+  );
+}
+
+/**
+ * One `TrackRow`'s worth of nothing.
+ *
+ * Every measurement here is copied from `TrackRow` itself, not eyeballed: the `w-6` index
+ * column, the unrounded `size-10` artwork, the `px-2 py-1.5` padding and the resulting 52px
+ * height it advertises via `contain-intrinsic-size`. A skeleton that is a few pixels off is what
+ * makes a list visibly resize the instant real rows replace it.
+ */
+export function TrackRowSkeleton({
+  delayMs = 0,
+  showArtwork = true,
+}: {
+  delayMs?: number;
+  showArtwork?: boolean;
+}) {
+  return (
+    <div className="flex h-[52px] w-full items-center gap-3 px-2 py-1.5">
+      <div className="flex w-6 shrink-0 justify-end">
+        <SkeletonBlock className="h-3 w-4" delayMs={delayMs} />
+      </div>
+      {showArtwork && <SkeletonBlock className="size-10 shrink-0" delayMs={delayMs} />}
+      <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+        <SkeletonBlock className="h-3.5 w-[55%]" delayMs={delayMs} />
+        <SkeletonBlock className="h-3 w-[32%]" delayMs={delayMs} />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * A stack of `TrackRowSkeleton`s standing in for a list of songs.
+ *
+ * Staggered by 60ms a row so the pulse sweeps down the list rather than every row blinking in
+ * lockstep, which reads as one shape rather than a queue of content arriving.
+ */
+export function TrackListSkeleton({
+  count = 8,
+  showArtwork = true,
+  label = "Loading songs",
+}: {
+  count?: number;
+  showArtwork?: boolean;
+  label?: string;
+}) {
+  return (
+    <div className="flex flex-col gap-0.5" role="status" aria-label={label}>
+      {Array.from({ length: count }, (_, index) => (
+        <TrackRowSkeleton key={index} delayMs={index * 60} showArtwork={showArtwork} />
+      ))}
+    </div>
+  );
+}
+
+/**
+ * One `AlbumCard`'s worth of nothing.
+ *
+ * `flex w-full flex-col gap-2 p-2` and the artwork's `rounded-none` are `AlbumCard`'s own
+ * classes, copied rather than approximated — the card's corners are square, not the rounded
+ * guess a generic "image placeholder" would reach for.
+ */
+export function AlbumCardSkeleton({ delayMs = 0 }: { delayMs?: number }) {
+  return (
+    <div className="flex w-full flex-col gap-2 p-2">
+      <SkeletonBlock className="aspect-square w-full rounded-none" delayMs={delayMs} />
+      <SkeletonBlock className="h-3.5 w-[78%]" delayMs={delayMs} />
+      <SkeletonBlock className="h-3 w-[48%]" delayMs={delayMs} />
+    </div>
+  );
+}
+
+/** A grid of `AlbumCardSkeleton`s, matching the `auto-fill,minmax(9.5rem,1fr)` grids they precede. */
+export function AlbumGridSkeleton({
+  count = 6,
+  label = "Loading",
+}: {
+  count?: number;
+  label?: string;
+}) {
+  return (
+    <div
+      className="grid gap-3 [grid-template-columns:repeat(auto-fill,minmax(9.5rem,1fr))]"
+      role="status"
+      aria-label={label}
+    >
+      {Array.from({ length: count }, (_, index) => (
+        <AlbumCardSkeleton key={index} delayMs={index * 60} />
+      ))}
+    </div>
+  );
+}
+
+/**
+ * One `PickCard`'s worth of nothing — a slot for `CylinderCarousel` itself, not a replacement
+ * for it.
+ *
+ * The carousel measures its own container and fits its curve, taper and item count to it (see
+ * its `ResizeObserver`); a hand-built row of skeleton cards next to it would need to duplicate
+ * all three and would still drift the moment either changed. Handing it these as `children`
+ * instead means the loading state is exactly as responsive as the real one, because it *is* the
+ * real one — only what fills each slot differs. `h-full` and `rounded-2xl` match the space the
+ * carousel gives every child and `PickCard`'s own outer corner.
+ */
+export function PickCardSkeleton() {
+  return <SkeletonBlock className="h-full w-full rounded-2xl" />;
+}

--- a/src/ui/pages/AlbumView.tsx
+++ b/src/ui/pages/AlbumView.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
-import { SpinnerSteps } from "@/components/motion/loader";
 import { CloseIcon, SearchIcon } from "@/ui/icons";
 import { TrackRow } from "../components/TrackRow";
+import { TrackListSkeleton } from "../components/Skeleton";
 import { useNowPlaying } from "../hooks/useNowPlaying";
 import type { Album, Track } from "../../datasource/types";
 import type { LibraryController } from "../../player/LibraryController";
@@ -37,14 +37,6 @@ interface AlbumViewProps {
 
 function getTrackRenderKey(track: Track, index: number): string {
   return track.playlistItemId ?? `${track.id}:${index}`;
-}
-
-function AlbumLoadingSpinner({ label }: { label: string }) {
-  return (
-    <div className="grid place-items-center px-2 py-16 text-muted-foreground" role="status" aria-live="polite" aria-label={label}>
-      <SpinnerSteps size={18} color="currentColor" />
-    </div>
-  );
 }
 
 export function AlbumView({ album, playerController, libraryController }: AlbumViewProps) {
@@ -205,9 +197,13 @@ export function AlbumView({ album, playerController, libraryController }: AlbumV
         onAddToPlaylist={() => openPlaylistPicker(tracks[0], tracks)}
         download={{ onStart: () => queueDownloads(tracks), counts: downloadCounts }}
       />
-      {isLoading && <AlbumLoadingSpinner label="Loading songs" />}
       {error && <p className="px-2 py-10 text-center text-sm text-muted-foreground">{error}</p>}
-      {!isLoading && !error && tracks.length > 0 && (
+      {/*
+       * The toolbar stands apart from the loading state below it: it doesn't depend on the
+       * tracks being in yet, and hiding it behind the skeleton would make every album page
+       * flash the search field in only once songs had already arrived.
+       */}
+      {!error && (isLoading || tracks.length > 0) && (
         <>
           <div
             className="flex flex-wrap items-center gap-1.5 self-start [&>button]:flex [&>button]:min-h-8 [&>button]:min-w-0 [&>button]:items-center [&>button]:justify-center [&>button]:gap-1.5 [&>button]:rounded-full [&>button]:bg-white/[0.04] [&>button]:px-3 [&>button]:text-sm [&>button]:font-medium [&>button]:text-muted-foreground [&>button]:transition-colors hover:[&>button]:bg-white/[0.08] hover:[&>button]:text-foreground focus-visible:[&>button]:outline-none focus-visible:[&>button]:ring-2 focus-visible:[&>button]:ring-ring"
@@ -243,7 +239,9 @@ export function AlbumView({ album, playerController, libraryController }: AlbumV
               )}
             </div>
           </div>
-          {visibleTracks.length === 0 && albumSearchQuery.trim() ? (
+          {isLoading ? (
+            <TrackListSkeleton label="Loading songs" />
+          ) : visibleTracks.length === 0 && albumSearchQuery.trim() ? (
             <p className="px-2 py-10 text-center text-sm text-muted-foreground">No songs match this search.</p>
           ) : (
             <div className="flex flex-col gap-0.5">

--- a/src/ui/pages/ArtistView.tsx
+++ b/src/ui/pages/ArtistView.tsx
@@ -23,6 +23,7 @@ import { shuffleTracks } from "../../player/shuffleTracks";
 import { AlbumCard } from "../components/AlbumCard";
 import { ArtistLinks } from "../components/ArtistLinks";
 import { MediaHeader } from "../components/MediaHeader";
+import { AlbumGridSkeleton, TrackListSkeleton } from "../components/Skeleton";
 import { TrackArtwork } from "../components/TrackArtwork";
 import { TrackRow } from "../components/TrackRow";
 import { useNowPlaying } from "../hooks/useNowPlaying";
@@ -391,7 +392,30 @@ export function ArtistView({
         }
       />
 
-      {isLoading && <p className="px-2 py-10 text-center text-sm text-muted-foreground">Loading artist...</p>}
+      {/*
+       * Section headings stay in place — only the rows/cards under them are placeholders. The
+       * release-type filter is left out here rather than shown empty: it lists whichever
+       * types this artist actually has (`releaseFilters`), which is not known before `page`
+       * arrives, so there is nothing honest to render there yet.
+       */}
+      {isLoading && (
+        <div className="flex flex-col gap-8">
+          <section className="flex flex-col gap-3">
+            <h2>Popular</h2>
+            <TrackListSkeleton count={POPULAR_PREVIEW_COUNT} label="Loading top songs" />
+          </section>
+          {/*
+            Releases has no fixed preview count — unlike Popular, every release the artist has
+            is shown. `AlbumGridSkeleton`'s own default is what "Listen again"/"More
+            recommendations" on Home use for the same reason: a guess at one row, not a real
+            number to match.
+          */}
+          <section className="flex flex-col gap-3">
+            <h2>Releases</h2>
+            <AlbumGridSkeleton label="Loading releases" />
+          </section>
+        </div>
+      )}
       {error && <p className="px-2 py-10 text-center text-sm text-muted-foreground">{error}</p>}
 
       {!isLoading && !error && page && (

--- a/src/ui/pages/HomePage.tsx
+++ b/src/ui/pages/HomePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { CylinderCarousel } from "@/components/motion/cylinder-carousel";
 import { PlayActiveIcon } from "@/ui/icons";
 import type { Track } from "../../datasource/types";
@@ -14,6 +14,7 @@ import { HomeDestinations, type HomeDestinationHandlers } from "../components/Ho
 import { ArtistLinks } from "../components/ArtistLinks";
 import { usePlayHistory } from "../../player/playHistory";
 import { useMadeForYouVisible } from "../settings/homeSections";
+import { AlbumGridSkeleton, PickCardSkeleton, TrackRowSkeleton } from "../components/Skeleton";
 
 const FALLBACK_QUERIES = [
   "new music",
@@ -33,6 +34,16 @@ const FALLBACK_QUERIES = [
 const PICKS_ASPECT = 3 / 4;
 const PICKS_VISIBLE_ITEMS = 5;
 const PICKS_ITEM_SIZE = 250;
+/** How far the carousel shrinks its edge cards. */
+const PICKS_MIN_SCALE = 0.72;
+
+/*
+ * Skeleton slots to feed the carousel while suggestions load. Unlike the other loading counts on
+ * this page, there is no real count to match here — `topSuggestions` does not exist yet — so
+ * this is just enough for the wraparound to feel like a shelf rather than three cards rattling
+ * around an empty drum.
+ */
+const PICKS_SKELETON_COUNT = 8;
 
 /*
  * Curve depth. The default is 35% of the item size, which on cards this large lifts the
@@ -47,6 +58,16 @@ const PICKS_ARC = 68;
  * edge rather than exactly hugging the card.
  */
 const PICKS_STAGE_HEIGHT = PICKS_ITEM_SIZE + PICKS_ARC ;
+
+/*
+ * How each section is sliced from the underlying lists — named rather than left as the literal
+ * arguments to `.slice()`, so a skeleton can ask for exactly this many placeholders instead of a
+ * second, hand-picked number that only happens to agree with the real count today.
+ */
+const RECENT_COMPACT_COUNT = 6;
+const RECENT_LARGE_COUNT = 18;
+const TOP_SUGGESTIONS_COUNT = 11;
+const MORE_SUGGESTIONS_COUNT = 12;
 
 const suggestionCache = new Map<string, Track[]>();
 const suggestionLoads = new Map<string, Promise<Track[]>>();
@@ -217,11 +238,20 @@ export function HomePage({
     suggestionCacheKey,
   ]);
 
-  const compactRecent = useMemo(() => recentPlays.slice(0, 6), [recentPlays]);
-  const largeRecent = useMemo(() => recentPlays.slice(6, 24), [recentPlays]);
-  const topSuggestions = suggestions.slice(0, 11);
-  const moreSuggestions = suggestions.slice(11, 23);
-  const surpriseSuggestions = suggestions.slice(11);
+  const compactRecent = useMemo(
+    () => recentPlays.slice(0, RECENT_COMPACT_COUNT),
+    [recentPlays],
+  );
+  const largeRecent = useMemo(
+    () => recentPlays.slice(RECENT_COMPACT_COUNT, RECENT_COMPACT_COUNT + RECENT_LARGE_COUNT),
+    [recentPlays],
+  );
+  const topSuggestions = suggestions.slice(0, TOP_SUGGESTIONS_COUNT);
+  const moreSuggestions = suggestions.slice(
+    TOP_SUGGESTIONS_COUNT,
+    TOP_SUGGESTIONS_COUNT + MORE_SUGGESTIONS_COUNT,
+  );
+  const surpriseSuggestions = suggestions.slice(TOP_SUGGESTIONS_COUNT);
 
   const playTrack = (track: Track, queue: readonly Track[]) => {
     void playerController.playTrackById(track.id, queue, true);
@@ -249,53 +279,68 @@ export function HomePage({
       <div className="flex items-center justify-between gap-3">
         <h3>Made for you</h3>
       </div>
-      {isLoadingSuggestions ? (
-        <div
-          className="h-[--stage] w-full animate-pulse rounded-2xl bg-card"
-          style={{ "--stage": `${PICKS_STAGE_HEIGHT}px` } as CSSProperties}
-          aria-label="Loading suggestions"
-        />
-      ) : (
+      {/*
+        The picks ride the inside of a cylinder instead of sitting in a grid: the row recedes
+        toward the middle and grows at the edges, so a shelf of recommendations reads as
+        something you roll through rather than a wall you scan. Drag, wheel or arrow-key it.
+
+        `key` forces a fresh mount on the swap from skeleton to real cards, rather than handing
+        one live instance a whole new set of children — `CylinderCarousel` keys its slides on
+        position ("slides are positional and stable", see its own render) because it is built
+        for a fixed deck, not one that gets replaced under it; reusing the instance carried the
+        skeleton's scroll position and measurements into the real carousel. A fresh mount still
+        gets the same `ResizeObserver`-driven sizing, curve and taper — just measured for the
+        content that is actually there.
+      */}
+      <CylinderCarousel
+        key={isLoadingSuggestions ? "skeleton" : "content"}
+        itemSize={PICKS_ITEM_SIZE}
+        height={PICKS_STAGE_HEIGHT}
+        visibleItems={PICKS_VISIBLE_ITEMS}
+        itemAspect={PICKS_ASPECT}
+        arc={PICKS_ARC}
         /*
-          The picks ride the inside of a cylinder instead of sitting in a grid: the row
-          recedes toward the middle and grows at the edges, so a shelf of recommendations
-          reads as something you roll through rather than a wall you scan. Drag, wheel or
-          arrow-key it. The same DiceCard/AlbumCard children as before — only the container
-          changed — so context menus, artist links and playback all behave identically.
+          Convex, not the default concave: a shelf of picks wants its hero in the middle
+          where the eye already is. Concave puts the *largest* cards at the container edge,
+          which is exactly where they get clipped — the biggest, loudest items end up half
+          cut off while the centre of attention holds the smallest one.
         */
-        <CylinderCarousel
-          itemSize={PICKS_ITEM_SIZE}
-          height={PICKS_STAGE_HEIGHT}
-          visibleItems={PICKS_VISIBLE_ITEMS}
-          itemAspect={PICKS_ASPECT}
-          arc={PICKS_ARC}
-          minScale={0.72}
+        minScale={PICKS_MIN_SCALE}
+        variant="convex"
+        className="-mx-4 cursor-grab active:cursor-grabbing overflow-x-clip overflow-y-visible"
+      >
+        {isLoadingSuggestions ? (
+          Array.from({ length: PICKS_SKELETON_COUNT }, (_, index) => (
+            <PickCardSkeleton key={index} />
+          ))
+        ) : (
           /*
-            Convex, not the default concave: a shelf of picks wants its hero in the middle
-            where the eye already is. Concave puts the *largest* cards at the container edge,
-            which is exactly where they get clipped — the biggest, loudest items end up half
-            cut off while the centre of attention holds the smallest one.
-          */
-          variant="convex"
-          className="-mx-4 cursor-grab active:cursor-grabbing overflow-x-clip overflow-y-visible"
-        >
-          <DiceCard
-            tracks={surpriseSuggestions}
-            isSpinning={isSurpriseSpinning}
-            onClick={playSurprise}
-          />
-          {topSuggestions.map((track) => (
-            <PickCard
-              key={track.id}
-              artworkUrl={track.artworkUrl}
-              title={track.title}
-              subtitle={track.artist}
-              onContextMenu={(event) => openTrackMenu(event, track)}
-              onSelect={() => playTrack(track, suggestions)}
-            />
-          ))}
-        </CylinderCarousel>
-      )}
+           * A real array, not a `<>Fragment</>` — `CylinderCarousel` walks its children with
+           * `Children.toArray`, which flattens an array but does not reach inside a Fragment.
+           * A Fragment here counted as a single slide holding all twelve cards, which block-
+           * flowed vertically inside that one slot instead of taking one slide each.
+           */
+          [
+            <DiceCard
+              key="dice"
+              tracks={surpriseSuggestions}
+              isSpinning={isSurpriseSpinning}
+              onClick={playSurprise}
+            />,
+            ...topSuggestions.map((track) => (
+              <PickCard
+                key={track.id}
+                artworkUrl={track.artworkUrl}
+                title={track.title}
+                subtitle={track.artist}
+                onContextMenu={(event) => openTrackMenu(event, track)}
+                onSelect={() => playTrack(track, suggestions)}
+              />
+            )),
+          ]
+        )}
+      </CylinderCarousel>
+      {isLoadingSuggestions && <span className="sr-only" role="status">Loading suggestions</span>}
 
     </section>
   );
@@ -314,11 +359,26 @@ export function HomePage({
         </section>
       )}
 
-      {showMadeForYou && !isLoadingSuggestions && madeForYouSection}
+      {showMadeForYou && madeForYouSection}
 
       {/* Directly under the carousel: the picks are what you came for, these are where you
           go when none of them appeal. */}
       <HomeDestinations {...destinations} />
+
+      {compactRecent.length === 0 && isWaitingForLibrary && (
+        <section className="flex flex-col gap-3">
+          <h2 className="text-lg font-semibold text-foreground">Recently played</h2>
+          <div
+            className="grid gap-1.5 [grid-template-columns:repeat(auto-fill,minmax(16rem,1fr))]"
+            role="status"
+            aria-label="Loading recently played"
+          >
+            {Array.from({ length: RECENT_COMPACT_COUNT }, (_, index) => (
+              <TrackRowSkeleton key={index} delayMs={index * 60} />
+            ))}
+          </div>
+        </section>
+      )}
 
       {compactRecent.length > 0 && (
         <section className="flex flex-col gap-3">
@@ -349,7 +409,12 @@ export function HomePage({
         </section>
       )}
 
-      {showMadeForYou && isLoadingSuggestions && madeForYouSection}
+      {moreSuggestions.length === 0 && isLoadingSuggestions && (
+        <section className="flex flex-col gap-3">
+          <h2 className="text-lg font-semibold text-foreground">More recommendations</h2>
+          <AlbumGridSkeleton count={MORE_SUGGESTIONS_COUNT} label="Loading more recommendations" />
+        </section>
+      )}
 
       {moreSuggestions.length > 0 && (
         <section className="flex flex-col gap-3">
@@ -366,6 +431,13 @@ export function HomePage({
               />
             ))}
           </div>
+        </section>
+      )}
+
+      {largeRecent.length === 0 && isWaitingForLibrary && (
+        <section className="flex flex-col gap-3">
+          <h2 className="text-lg font-semibold text-foreground">Listen again</h2>
+          <AlbumGridSkeleton count={RECENT_LARGE_COUNT} label="Loading listen again" />
         </section>
       )}
 

--- a/src/ui/pages/PlaylistView.tsx
+++ b/src/ui/pages/PlaylistView.tsx
@@ -18,6 +18,7 @@ import { queueDownloads, useOfflineState } from "../../player/offlineStore";
 import { usePlaylistContextMenu } from "../components/PlaylistContextMenu";
 import { formatCollectionMeta, MediaHeader } from "../components/MediaHeader";
 import { isLikedSongsId, likedSongsCover } from "../likedSongsArtwork";
+import { TrackListSkeleton } from "../components/Skeleton";
 import { TrackRow } from "../components/TrackRow";
 import { useNowPlaying } from "../hooks/useNowPlaying";
 import { useKeyboardShortcuts } from "../settings/keyboardShortcuts";
@@ -791,7 +792,6 @@ export function PlaylistView({ playlist, playerController, libraryController }: 
         />
         <PlaylistDescription playlist={playlist} libraryController={libraryController} />
       </div>
-      {isLoading && <PlaylistLoadingSpinner label="Loading songs" />}
       {error && <p className="px-2 py-10 text-center text-sm text-muted-foreground">{error}</p>}
       {!isLoading && !error && !hasMoreTracks && tracks.length === 0 && (
         <p className="px-2 py-10 text-center text-sm text-muted-foreground">
@@ -801,7 +801,12 @@ export function PlaylistView({ playlist, playerController, libraryController }: 
             : "This playlist is empty."}
         </p>
       )}
-      {!isLoading && !error && (tracks.length > 0 || hasMoreTracks) && (
+      {/*
+       * Sort and search stand apart from the loading state below them: they don't depend on
+       * the tracks being in yet, and hiding them behind the skeleton would make every playlist
+       * flash them in only once songs had already arrived.
+       */}
+      {!error && (isLoading || tracks.length > 0 || hasMoreTracks) && (
         <>
           <div
             className="flex flex-wrap items-center gap-1.5 self-start [&>button]:flex [&>button]:min-h-8 [&>button]:min-w-0 [&>button]:items-center [&>button]:justify-center [&>button]:gap-1.5 [&>button]:rounded-full [&>button]:bg-white/[0.04] [&>button]:px-3 [&>button]:text-sm [&>button]:font-medium [&>button]:text-muted-foreground [&>button]:transition-colors hover:[&>button]:bg-white/[0.08] hover:[&>button]:text-foreground focus-visible:[&>button]:outline-none focus-visible:[&>button]:ring-2 focus-visible:[&>button]:ring-ring"
@@ -868,7 +873,9 @@ export function PlaylistView({ playlist, playerController, libraryController }: 
               )}
             </div>
           </div>
-          {visibleTracks.length === 0 && playlistSearchQuery.trim() ? (
+          {isLoading ? (
+            <TrackListSkeleton label="Loading songs" />
+          ) : visibleTracks.length === 0 && playlistSearchQuery.trim() ? (
             <p className="px-2 py-10 text-center text-sm text-muted-foreground">No songs match this search.</p>
           ) : (
           <div className="flex flex-col gap-0.5">
@@ -933,17 +940,19 @@ export function PlaylistView({ playlist, playerController, libraryController }: 
             })}
           </div>
           )}
-          <div ref={loadMoreRef} className="px-2 py-4 text-center text-sm text-muted-foreground" aria-live="polite">
-            {isLoadingMore ? (
-              <PlaylistLoadingSpinner label="Loading more songs" />
-            ) : loadMoreError ? (
-              loadMoreError
-            ) : hasMoreTracks ? (
-              ""
-            ) : (
-              ""
-            )}
-          </div>
+          {!isLoading && (
+            <div ref={loadMoreRef} className="px-2 py-4 text-center text-sm text-muted-foreground" aria-live="polite">
+              {isLoadingMore ? (
+                <PlaylistLoadingSpinner label="Loading more songs" />
+              ) : loadMoreError ? (
+                loadMoreError
+              ) : hasMoreTracks ? (
+                ""
+              ) : (
+                ""
+              )}
+            </div>
+          )}
         </>
       )}
       <SelectionBar


### PR DESCRIPTION
- Skeleton.tsx: row/card/pick skeletons sized off the real components, not approximated
- Placeholder counts match real slice sizes instead of hand-picked numbers
- Home's Made for you carousel skeletons use the real CylinderCarousel with placeholder slides, so sizing/curve/responsiveness match exactly
- Album/Playlist: search (and sort) controls stay visible while loading; only the row list is skeletoned
- Artist: Popular/Releases headings stay visible; only their rows/cards are skeletoned