### PR TITLE
feat: add Start radio to track context menu

### DIFF
--- a/src/player/PlayerController.ts
+++ b/src/player/PlayerController.ts
@@ -1116,6 +1116,7 @@ export class PlayerController {
     }
 
     this.queue.replaceAutomaticUpcoming(recommendations);
+    this.emit();
   }
 
   private async refreshRestoredTrackMetadata(track: Track, restoreRequestId: number): Promise<void> {

--- a/src/ui/components/TrackContextMenu.tsx
+++ b/src/ui/components/TrackContextMenu.tsx
@@ -8,7 +8,7 @@ import {
   useState,
   useSyncExternalStore,
 } from "react";
-import { AlbumIcon, CheckIcon, CloseIcon, CompassIcon, DownloadIcon, HeartActiveIcon, HeartIcon, LinkIcon, ListIcon, PencilIcon, PlaylistAddIcon, PlaylistIcon, SearchIcon, SkipNextIcon, TrashIcon } from "@/ui/icons";
+import { AlbumIcon, CheckIcon, CloseIcon, CompassIcon, DownloadIcon, HeartActiveIcon, HeartIcon, LinkIcon, ListIcon, PencilIcon, PlaylistAddIcon, PlaylistIcon, RadioIcon, SearchIcon, SkipNextIcon, TrashIcon } from "@/ui/icons";
 import type { Playlist, Track, TrackRating } from "../../datasource/types";
 import {
   TrackContextMenuContext,
@@ -303,6 +303,13 @@ export function TrackContextMenuProvider({
     showToast(`"${track.title}" will play next`);
   };
 
+  /** Plays the track solo and lets autoplay fill the rest, seeded from it — a YT Music mix. */
+  const startRadio = () => {
+    if (!track) return;
+    setMenuPosition(null);
+    void playerController.playTrackById(track.id, [track], true);
+  };
+
   const copyLink = async () => {
     if (!track) return;
     const selectedTrack = track;
@@ -556,6 +563,13 @@ export function TrackContextMenuProvider({
             <ListIcon size={18} aria-hidden="true" />
             <span className="flex-1">Add to queue</span>
           </button>
+          {/* Needs a YouTube video id to seed the mix — a local file has nothing to seed from. */}
+          {track.source !== "local" && (
+            <button type="button" role="menuitem" className="flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-sm text-foreground transition-colors hover:bg-card disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring" onClick={startRadio}>
+              <RadioIcon size={18} aria-hidden="true" />
+              <span className="flex-1">Start radio</span>
+            </button>
+          )}
           <button type="button" role="menuitem" className="flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-sm text-foreground transition-colors hover:bg-card disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring" onClick={openPicker}>
             <PlaylistAddIcon size={18} aria-hidden="true" />
             <span className="flex-1">Add to playlist</span>

--- a/src/ui/icons.tsx
+++ b/src/ui/icons.tsx
@@ -77,6 +77,7 @@ export { Home2Icon as HomeActiveIcon } from "@solar-icons/react/bold/home-2";
 export { SidebarMinimalisticIcon as QueuePanelIcon } from "@solar-icons/react/linear/sidebar-minimalistic";
 export { MagnifierIcon as SearchIcon } from "@solar-icons/react/linear/magnifier";
 export { CompassIcon } from "@solar-icons/react/linear/compass";
+export { RadioIcon } from "@solar-icons/react/linear/radio";
 export { PaletteIcon } from "@solar-icons/react/linear/palette";
 export { PaletteIcon as PaletteActiveIcon } from "@solar-icons/react/bold/palette";
 export { SettingsIcon } from "@solar-icons/react/linear/settings";


### PR DESCRIPTION
Adds "Start radio" to the track context menu — plays the track and seeds the queue with recommendations via the existing autoplay/getUpNext path (same one `generateQueueAfter` already uses from the queue panel), just exposed as a direct action.

Closes #91