### PR TITLE
chore: bump version to 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zuno",
   "private": true,
-  "version": "1.3.2",
+  "version": "1.4.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6886,7 +6886,7 @@ checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zuno"
-version = "1.3.2"
+version = "1.4.0"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zuno"
-version = "1.3.2"
+version = "1.4.0"
 description = "Zuno - a desktop music client"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Zuno",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "identifier": "com.zuno.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/internal/releaseNote.ts
+++ b/src/internal/releaseNote.ts
@@ -23,11 +23,11 @@ import { getAppSetting, setAppSetting } from "./appSettings";
  */
 const SEEN_VERSION_KEY = "release-note-seen-version";
 
-export const RELEASE_NOTE_BODY = `**Lyrics** — full screen mode.
-**Linux** — native media controls from your desktop and lock screen, and a setting for native window decorations.
-**Lighter** — smoother scrolling and dragging, reduced motion support, and the mini player now matches your theme.
-**Playback** — fewer failed or stalled tracks, and the first song of a session starts sooner.
-**Fixes** — queue position, artist photos, playlist tags and YouTube channel selection all stick properly now.
+export const RELEASE_NOTE_BODY = `**Accounts** — switch between multiple YouTube Music accounts instantly, no signing out required.
+**Sound** — pick your exact output device (real speaker/headphone names on Linux too), plus a bypass toggle and mini EQ right in the player bar.
+**Playlists** — shuffle now truly shuffles the whole playlist from wherever you are in it, loop cycles properly instead of getting stuck, and any playlist can be hidden from your library.
+**Discovery** — start a radio station from any track, and pages load in with proper skeletons instead of a blank flash.
+**Fixes** — some tracks auto-skipping a few seconds in, crossfade stalling when minimized, YouTube embed errors now falling back automatically, and a second launch refocusing Zuno instead of opening twice.
 
 Report anything broken on GitHub, or come say hello at /r/ZunoMusic.
 


### PR DESCRIPTION
Version bump for the 1.4.0 release (package.json, tauri.conf.json, Cargo.toml/lock) plus the in-app release note text.

GitHub release notes get applied separately via an annotated tag once this merges, so `release.yml` picks up the real changelog instead of the default merge-commit message.

Not tagging/releasing until this is merged and I get the go-ahead.