### PR TITLE
fix: added hours to playing time in seekbar

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -5,14 +5,25 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
+function pad(num: number) {
+  return String(num).padStart(2, "0");
+} 
+
 /**
- * `m:ss` for a whole-second duration. Callers round `seconds` themselves (floor for elapsed
+ * Formats a whole-second duration as `hh:mm:ss` or just `mm:ss`,
+ * depending on the real duration (if greater or less than 1 hour).
+ * Callers round `seconds` themselves (floor for elapsed
  * position, ceil for a countdown) — this only formats what it's given.
  */
-export function formatMinutesSeconds(seconds: number): string {
-  if (!Number.isFinite(seconds)) return "0:00";
-  const whole = Math.max(0, Math.floor(seconds));
-  const mins = Math.floor(whole / 60);
-  const secs = whole % 60;
-  return `${mins}:${secs.toString().padStart(2, "0")}`;
+export function formatMinutesSeconds(totalSeconds: number): string {
+  if (!Number.isFinite(totalSeconds)) return "0:00";
+
+  const hours = Math.floor(totalSeconds / 3600);
+  const mins = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = Math.floor(totalSeconds % 60);
+
+  if (hours > 0) {
+    return `${pad(hours)}:${pad(mins)}:${pad(seconds)}`;
+  }
+  return `${pad(mins)}:${pad(seconds)}`;
 }

--- a/src/ui/components/player/SeekBar.tsx
+++ b/src/ui/components/player/SeekBar.tsx
@@ -266,7 +266,7 @@ export function SeekBar() {
         } as React.CSSProperties}
         aria-label="Seek"
       />
-      <span className="w-10 shrink-0 text-xs tabular-nums text-muted-foreground">
+      <span className="w-10 shrink-0 text-xs tabular-nums text-muted-foreground mr-4">
         {formatTime(duration)}
       </span>
     </div>


### PR DESCRIPTION
## What and why

If a song lasts more than 1 hour, the format of the playing time is 'mm:ss', e.g. '160:00'. 
It should be 'hh:mm:ss', e.g. '02:40:00' instead

<!-- What changed, and the problem it solves. One paragraph is plenty. -->
Updated function `formatMinutesSeconds` to take into account hours.

Closes #126 

## How it was checked

<!-- Delete what does not apply. -->

- [x] `npm run verify` passes
- [x] Ran the app and used the affected screen
- [x] Screenshot or clip below (UI changes)

**Before**
<img width="240" height="96" alt="Screenshot From 2026-09-03 16-21-49" src="https://github.com/user-attachments/assets/12aa3540-74c4-4420-8fa8-79ea4a527aa9" />


**After**
<img width="227" height="85" alt="image" src="https://github.com/user-attachments/assets/6c71f883-0c60-4584-a93d-32fe24d3a95e" />

## Notes for the reviewer
I left the function name unchanged `formatMinutesSeconds` and not `formatHoursMinutesSeconds` because I think it's not much relevant.

<!-- Anything non-obvious: a tradeoff, a shortcut left in, a follow-up needed. -->
